### PR TITLE
feat: add orphan resource cleanup during reconcile

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -13,6 +13,7 @@ on:
       - 'internal/**'
       - 'config/**'
       - 'hack/**'
+      - 'test/**'
       - 'Dockerfile'
       - 'go.mod'
       - 'go.sum'
@@ -48,10 +49,13 @@ jobs:
           OPERATOR_IMG: ${{ env.OPERATOR_IMG }}
           KIND_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
 
-      - name: Run integration tests
-        run: make test-e2e
+      - name: Run batch-gateway e2e tests
+        run: make test-e2e-batch-gateway
         env:
           TEST_APISERVER_URL: "http://localhost:8000"
+
+      - name: Run operator e2e tests
+        run: make test-e2e-operator
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'cmd/**'
+      - 'api/**'
+      - 'internal/**'
+      - 'batch-gateway/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+
+jobs:
+  test:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Verify generated code is up to date
+        run: |
+          make generate manifests
+          git diff --exit-code -- api/ config/crd/
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ generate:
 .PHONY: test
 test: generate manifests setup-envtest
 	KUBEBUILDER_ASSETS="$$($(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	go test ./... -race -count=1
+	go test -v ./... -race -count=1
 
 .PHONY: setup-envtest
 setup-envtest:
@@ -83,9 +83,13 @@ dev-rm-cluster:
 # TODO: enable more e2e tests (currently only running Batches/Lifecycle as a smoke test)
 TEST_RUN ?= TestE2E/Batches/Lifecycle
 
-.PHONY: test-e2e
-test-e2e:
+.PHONY: test-e2e-batch-gateway
+test-e2e-batch-gateway:
 	cd batch-gateway/test/e2e && go test -v -count=1 -run "$(TEST_RUN)" ./...
+
+.PHONY: test-e2e-operator
+test-e2e-operator:
+	cd test/e2e && go test -v -count=1 -timeout 5m ./...
 
 ## Submodule
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Kubernetes operator that manages the lifecycle of [batch-gateway](https://github.com/opendatahub-io/batch-gateway) deployments. It reconciles a single `LLMBatchGateway` custom resource into the full set of Kubernetes resources by rendering the upstream Helm chart at runtime.
 
+[Design Document](https://docs.google.com/document/d/1cYrR-GRnFEfaG-D2WwJqK5c8m6iq3QHyPHs6KMjou0o/edit?usp=sharing)
+
 ```
 LLMBatchGateway CR
        |

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -54,8 +54,6 @@ type LLMBatchGatewaySpec struct {
 type SecretReference struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
-
-	Namespace string `json:"namespace,omitempty"`
 }
 
 // --- File Storage ---

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -452,8 +452,6 @@ spec:
                 properties:
                   name:
                     type: string
-                  namespace:
-                    type: string
                 required:
                 - name
                 type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,8 +48,6 @@ rules:
   resources:
   - llmbatchgateways
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -320,15 +320,15 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway) (map[string]interface{}
 	return vals, nil
 }
 
-// splitImage splits "repo:tag" into (repo, tag). If no tag, returns "latest".
+// splitImage splits an image reference into (repository, tag).
+// For digest references like "repo@sha256:abc", it splits on the last ":"
+// producing ("repo@sha256", "abc"). The chart template reconstructs this
+// via printf "%s:%s" back into the correct "repo@sha256:abc" format.
 func splitImage(image string) (string, string) {
-	// Handle images with registry port like ghcr.io:443/org/repo:tag
-	// Split on the last ":"
 	lastColon := strings.LastIndex(image, ":")
 	if lastColon == -1 {
 		return image, "latest"
 	}
-	// If the part after the last colon contains a "/", it's a port not a tag
 	afterColon := image[lastColon+1:]
 	if strings.Contains(afterColon, "/") {
 		return image, "latest"

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -48,10 +48,22 @@ func TestSplitImage(t *testing.T) {
 			wantTag:  "latest",
 		},
 		{
-			name:     "image with sha digest",
+			name:     "image with sha tag prefix",
 			image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver:sha-abc123",
 			wantRepo: "ghcr.io/llm-d-incubation/batch-gateway-apiserver",
 			wantTag:  "sha-abc123",
+		},
+		{
+			name:     "digest splits so chart reconstructs repo@sha256:hex correctly",
+			image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver@sha256:abc123def456",
+			wantRepo: "ghcr.io/llm-d-incubation/batch-gateway-apiserver@sha256",
+			wantTag:  "abc123def456",
+		},
+		{
+			name:     "digest with registry port",
+			image:    "registry.example.com:5000/batch-gateway-apiserver@sha256:abc123def456",
+			wantRepo: "registry.example.com:5000/batch-gateway-apiserver@sha256",
+			wantTag:  "abc123def456",
 		},
 	}
 

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -9,12 +10,14 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	batchv1alpha1 "github.com/opendatahub-io/llm-d-batch-gateway-operator/api/v1alpha1"
 )
@@ -27,7 +30,27 @@ const (
 	fieldOwner = "llmbatchgateway-controller"
 )
 
-// +kubebuilder:rbac:groups=batch.llm-d.ai,resources=llmbatchgateways,verbs=get;list;watch;create;update;patch;delete
+// managedGVKs must be a superset of all GVK types the Helm chart can produce.
+// Update this list when adding new resource types to the chart.
+var managedGVKs = []schema.GroupVersionKind{
+	{Group: "apps", Version: "v1", Kind: "Deployment"},
+	{Group: "", Version: "v1", Kind: "Service"},
+	{Group: "", Version: "v1", Kind: "ConfigMap"},
+	{Group: "", Version: "v1", Kind: "ServiceAccount"},
+	{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"},
+	{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"},
+	{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"},
+	{Group: "monitoring.coreos.com", Version: "v1", Kind: "PodMonitor"},
+	{Group: "monitoring.coreos.com", Version: "v1", Kind: "PrometheusRule"},
+}
+
+type resourceKey struct {
+	Group string
+	Kind  string
+	Name  string
+}
+
+// +kubebuilder:rbac:groups=batch.llm-d.ai,resources=llmbatchgateways,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=batch.llm-d.ai,resources=llmbatchgateways/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=batch.llm-d.ai,resources=llmbatchgateways/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
@@ -53,6 +76,22 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("fetching LLMBatchGateway: %w", err)
+	}
+
+	if err := validateSpec(&gw); err != nil {
+		for _, condType := range []string{ConditionReady, ConditionAPIServerAvailable, ConditionProcessorAvailable} {
+			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
+				Type:               condType,
+				Status:             metav1.ConditionFalse,
+				Reason:             "ValidationFailed",
+				Message:            err.Error(),
+				ObservedGeneration: gw.Generation,
+			})
+		}
+		if statusErr := r.Status().Update(ctx, &gw); statusErr != nil {
+			return ctrl.Result{}, fmt.Errorf("updating status after validation failure: %w", statusErr)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	objects, err := r.HelmRenderer.RenderChart(&gw)
@@ -87,11 +126,79 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		logger.V(2).Info("applied resource", "kind", obj.GetKind(), "name", obj.GetName())
 	}
 
+	if err := r.deleteOrphanedResources(ctx, &gw, objects); err != nil {
+		return ctrl.Result{}, fmt.Errorf("deleting orphaned resources: %w", err)
+	}
+
 	if err := r.updateStatus(ctx, &gw); err != nil {
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *LLMBatchGatewayReconciler) deleteOrphanedResources(
+	ctx context.Context,
+	gw *batchv1alpha1.LLMBatchGateway,
+	renderedObjects []*unstructured.Unstructured,
+) error {
+	logger := log.FromContext(ctx)
+
+	desired := make(map[resourceKey]struct{}, len(renderedObjects))
+	for _, obj := range renderedObjects {
+		gvk := obj.GroupVersionKind()
+		desired[resourceKey{
+			Group: gvk.Group,
+			Kind:  gvk.Kind,
+			Name:  obj.GetName(),
+		}] = struct{}{}
+	}
+
+	var errs []error
+	for _, gvk := range managedGVKs {
+		var list unstructured.UnstructuredList
+		list.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   gvk.Group,
+			Version: gvk.Version,
+			Kind:    gvk.Kind + "List",
+		})
+
+		// TODO: use client.MatchingLabels for GVKs that have consistent labels to reduce API server load
+		if err := r.List(ctx, &list, client.InNamespace(gw.Namespace)); err != nil {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				logger.V(1).Info("skipping orphan check (CRD not installed)", "kind", gvk.Kind)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("listing %s: %w", gvk.Kind, err))
+			continue
+		}
+
+		for i := range list.Items {
+			item := &list.Items[i]
+			if !isControllerOwnedBy(item, gw) {
+				continue
+			}
+
+			key := resourceKey{
+				Group: gvk.Group,
+				Kind:  gvk.Kind,
+				Name:  item.GetName(),
+			}
+			if _, ok := desired[key]; ok {
+				continue
+			}
+
+			logger.Info("deleting orphaned resource", "kind", gvk.Kind, "name", item.GetName())
+			if err := r.Delete(ctx, item); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				errs = append(errs, fmt.Errorf("deleting %s/%s: %w", gvk.Kind, item.GetName(), err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv1alpha1.LLMBatchGateway) error {
@@ -169,6 +276,19 @@ func (r *LLMBatchGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+func isControllerOwnedBy(obj metav1.Object, owner *batchv1alpha1.LLMBatchGateway) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == owner.UID &&
+			ref.Kind == "LLMBatchGateway" &&
+			ref.APIVersion == batchv1alpha1.GroupVersion.String() &&
+			ref.Controller != nil &&
+			*ref.Controller {
+			return true
+		}
+	}
+	return false
+}
+
 func isOwnedBy(obj metav1.Object, owner *batchv1alpha1.LLMBatchGateway) bool {
 	for _, ref := range obj.GetOwnerReferences() {
 		if ref.UID == owner.UID {
@@ -190,6 +310,18 @@ func conditionReason(ok bool, trueReason, falseReason string) string {
 		return trueReason
 	}
 	return falseReason
+}
+
+func validateSpec(gw *batchv1alpha1.LLMBatchGateway) error {
+	hasGlobal := gw.Spec.Processor.GlobalInferenceGateway != nil
+	hasModel := len(gw.Spec.Processor.ModelGateways) > 0
+	if !hasGlobal && !hasModel {
+		return fmt.Errorf("processor must have either globalInferenceGateway or modelGateways configured")
+	}
+	if hasGlobal && hasModel {
+		return fmt.Errorf("processor cannot have both globalInferenceGateway and modelGateways configured")
+	}
+	return nil
 }
 
 var _ reconcile.Reconciler = (*LLMBatchGatewayReconciler)(nil)

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -270,6 +270,218 @@ func TestReconcile(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("deletes orphaned resources on spec change", func(t *testing.T) {
+		gw := newTestGateway("test-orphan", "default")
+		gw.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: true}
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = k8sClient.Delete(ctx, gw)
+		})
+
+		nn := types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		if err != nil {
+			t.Fatalf("first Reconcile() error: %v", err)
+		}
+
+		var cmList corev1.ConfigMapList
+		if err := k8sClient.List(ctx, &cmList); err != nil {
+			t.Fatalf("listing configmaps: %v", err)
+		}
+		cmCountBefore := 0
+		hasDashboard := false
+		for _, cm := range cmList.Items {
+			if !isOwnedByUID(cm.OwnerReferences, gw.UID) {
+				continue
+			}
+			cmCountBefore++
+			if cm.Labels["grafana_dashboard"] == "1" {
+				hasDashboard = true
+			}
+		}
+		if !hasDashboard {
+			t.Fatal("expected grafana dashboard ConfigMap to exist after first reconcile")
+		}
+
+		if err := k8sClient.Get(ctx, nn, gw); err != nil {
+			t.Fatalf("getting CR for update: %v", err)
+		}
+		gw.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: false}
+		if err := k8sClient.Update(ctx, gw); err != nil {
+			t.Fatalf("updating CR: %v", err)
+		}
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		if err != nil {
+			t.Fatalf("second Reconcile() error: %v", err)
+		}
+
+		if err := k8sClient.List(ctx, &cmList); err != nil {
+			t.Fatalf("listing configmaps after: %v", err)
+		}
+		cmCountAfter := 0
+		for _, cm := range cmList.Items {
+			if !isOwnedByUID(cm.OwnerReferences, gw.UID) {
+				continue
+			}
+			cmCountAfter++
+			if cm.Labels["grafana_dashboard"] == "1" {
+				t.Error("grafana dashboard ConfigMap should have been deleted")
+			}
+		}
+		if cmCountAfter != cmCountBefore-1 {
+			t.Errorf("configmap count = %d, want %d (one dashboard removed)", cmCountAfter, cmCountBefore-1)
+		}
+	})
+
+	t.Run("sets ValidationFailed when no inference gateway configured", func(t *testing.T) {
+		gw := newTestGateway("test-validation-none", "default")
+		gw.Spec.Processor.GlobalInferenceGateway = nil
+		gw.Spec.Processor.ModelGateways = nil
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = k8sClient.Delete(ctx, gw)
+		})
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace},
+		})
+		if err != nil {
+			t.Fatalf("Reconcile() should not return error for validation failure, got: %v", err)
+		}
+
+		var updated batchv1alpha1.LLMBatchGateway
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace}, &updated); err != nil {
+			t.Fatalf("getting updated CR: %v", err)
+		}
+
+		for _, condType := range []string{ConditionReady, ConditionAPIServerAvailable, ConditionProcessorAvailable} {
+			found := false
+			for _, c := range updated.Status.Conditions {
+				if c.Type == condType {
+					found = true
+					if c.Status != metav1.ConditionFalse {
+						t.Errorf("%s status = %v, want False", condType, c.Status)
+					}
+					if c.Reason != "ValidationFailed" {
+						t.Errorf("%s reason = %v, want ValidationFailed", condType, c.Reason)
+					}
+					break
+				}
+			}
+			if !found {
+				t.Errorf("missing condition %s", condType)
+			}
+		}
+	})
+
+	t.Run("sets ValidationFailed when both gateways configured", func(t *testing.T) {
+		gw := newTestGateway("test-validation-both", "default")
+		gw.Spec.Processor.GlobalInferenceGateway = &batchv1alpha1.InferenceGatewaySpec{
+			URL: "http://global:8000",
+		}
+		gw.Spec.Processor.ModelGateways = map[string]batchv1alpha1.InferenceGatewaySpec{
+			"model-a": {URL: "http://model-a:8000"},
+		}
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = k8sClient.Delete(ctx, gw)
+		})
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace},
+		})
+		if err != nil {
+			t.Fatalf("Reconcile() should not return error for validation failure, got: %v", err)
+		}
+
+		var updated batchv1alpha1.LLMBatchGateway
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace}, &updated); err != nil {
+			t.Fatalf("getting updated CR: %v", err)
+		}
+
+		for _, c := range updated.Status.Conditions {
+			if c.Type == ConditionReady {
+				if c.Status != metav1.ConditionFalse {
+					t.Errorf("Ready status = %v, want False", c.Status)
+				}
+				if c.Reason != "ValidationFailed" {
+					t.Errorf("Ready reason = %v, want ValidationFailed", c.Reason)
+				}
+				return
+			}
+		}
+		t.Error("missing Ready condition")
+	})
+
+	t.Run("does not delete resources owned by a different CR", func(t *testing.T) {
+		gwA := newTestGateway("test-orphan-a", "default")
+		gwA.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: true}
+		gwB := newTestGateway("test-orphan-b", "default")
+		gwB.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: true}
+
+		if err := k8sClient.Create(ctx, gwA); err != nil {
+			t.Fatalf("creating CR A: %v", err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, gwA) })
+		if err := k8sClient.Create(ctx, gwB); err != nil {
+			t.Fatalf("creating CR B: %v", err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, gwB) })
+
+		nnA := types.NamespacedName{Name: gwA.Name, Namespace: gwA.Namespace}
+		nnB := types.NamespacedName{Name: gwB.Name, Namespace: gwB.Namespace}
+
+		if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nnA}); err != nil {
+			t.Fatalf("Reconcile A: %v", err)
+		}
+		if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nnB}); err != nil {
+			t.Fatalf("Reconcile B: %v", err)
+		}
+
+		var cmList corev1.ConfigMapList
+		if err := k8sClient.List(ctx, &cmList); err != nil {
+			t.Fatalf("listing configmaps: %v", err)
+		}
+		cmCountB := 0
+		for _, cm := range cmList.Items {
+			if isOwnedByUID(cm.OwnerReferences, gwB.UID) {
+				cmCountB++
+			}
+		}
+
+		if err := k8sClient.Get(ctx, nnA, gwA); err != nil {
+			t.Fatalf("getting CR A: %v", err)
+		}
+		gwA.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: false}
+		if err := k8sClient.Update(ctx, gwA); err != nil {
+			t.Fatalf("updating CR A: %v", err)
+		}
+		if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nnA}); err != nil {
+			t.Fatalf("Reconcile A after update: %v", err)
+		}
+
+		if err := k8sClient.List(ctx, &cmList); err != nil {
+			t.Fatalf("listing configmaps after: %v", err)
+		}
+		cmCountBAfter := 0
+		for _, cm := range cmList.Items {
+			if isOwnedByUID(cm.OwnerReferences, gwB.UID) {
+				cmCountBAfter++
+			}
+		}
+		if cmCountBAfter != cmCountB {
+			t.Errorf("CR B configmap count changed from %d to %d", cmCountB, cmCountBAfter)
+		}
+	})
 }
 
 func isOwnedByUID(refs []metav1.OwnerReference, uid types.UID) bool {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,92 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+var (
+	testNamespace = getEnvOrDefault("TEST_NAMESPACE", "default")
+	testCRName    = getEnvOrDefault("TEST_CR_NAME", "batch-gateway")
+)
+
+func TestE2E(t *testing.T) {
+	t.Run("Operator", func(t *testing.T) {
+		t.Run("StatusConditions", testStatusConditions)
+		t.Run("OrphanCleanup", testOrphanCleanup)
+		t.Run("SpecUpdate", testSpecUpdate)
+	})
+}
+
+func testStatusConditions(t *testing.T) {
+	expected := []string{"Ready", "APIServerAvailable", "ProcessorAvailable"}
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		conditions := getCRConditions(t, testCRName, testNamespace)
+		found := map[string]bool{}
+		for _, c := range conditions {
+			if typ, ok := c["type"].(string); ok {
+				found[typ] = true
+			}
+		}
+		allPresent := true
+		for _, e := range expected {
+			if !found[e] {
+				allPresent = false
+				break
+			}
+		}
+		if allPresent {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for status conditions: %v", expected)
+}
+
+func testOrphanCleanup(t *testing.T) {
+	dashboardCM := testCRName + "-batch-gateway-dashboards"
+
+	kubectlPatch(t, "llmbatchgateway", testCRName, testNamespace,
+		`{"spec":{"grafana":{"enabled":true}}}`)
+	t.Cleanup(func() {
+		kubectlPatch(t, "llmbatchgateway", testCRName, testNamespace,
+			`{"spec":{"grafana":{"enabled":false}}}`)
+		waitForResourceGone(t, "configmap", dashboardCM, testNamespace, 60*time.Second)
+	})
+
+	waitForResourceExists(t, "configmap", dashboardCM, testNamespace, 60*time.Second)
+
+	kubectlPatch(t, "llmbatchgateway", testCRName, testNamespace,
+		`{"spec":{"grafana":{"enabled":false}}}`)
+
+	waitForResourceGone(t, "configmap", dashboardCM, testNamespace, 60*time.Second)
+}
+
+func testSpecUpdate(t *testing.T) {
+	deploymentName := findDeploymentByComponent(t, testNamespace, testCRName, "apiserver")
+
+	original := getDeploymentReplicas(t, deploymentName, testNamespace)
+	target := original + 1
+
+	kubectlPatch(t, "llmbatchgateway", testCRName, testNamespace,
+		`{"spec":{"apiServer":{"replicas":`+itoa(target)+`}}}`)
+	t.Cleanup(func() {
+		kubectlPatch(t, "llmbatchgateway", testCRName, testNamespace,
+			`{"spec":{"apiServer":{"replicas":`+itoa(original)+`}}}`)
+	})
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if getDeploymentReplicas(t, deploymentName, testNamespace) == target {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("deployment %s replicas did not update to %d", deploymentName, target)
+}
+
+func itoa(n int64) string {
+	return fmt.Sprintf("%d", n)
+}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,0 +1,3 @@
+module github.com/opendatahub-io/llm-d-batch-gateway-operator/test/e2e
+
+go 1.25.0

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,148 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const pollInterval = 2 * time.Second
+
+func getEnvOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func kubectl(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	return cmd.CombinedOutput()
+}
+
+func kubectlPatch(t *testing.T, resource, name, namespace, patchJSON string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := kubectl(ctx, "patch", resource, name, "-n", namespace, "--type", "merge", "-p", patchJSON)
+	if err != nil {
+		t.Fatalf("kubectl patch %s %s: %v\n%s", resource, name, err, out)
+	}
+}
+
+func kubectlGetExists(t *testing.T, resource, name, namespace string) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := kubectl(ctx, "get", resource, name, "-n", namespace, "--no-headers")
+	if err == nil {
+		return true
+	}
+	if strings.Contains(string(out), "NotFound") {
+		return false
+	}
+	t.Fatalf("kubectl get %s %s: %v\n%s", resource, name, err, out)
+	return false
+}
+
+func kubectlGetJSON(t *testing.T, resource, name, namespace string) map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	out, err := kubectl(ctx, "get", resource, name, "-n", namespace, "-o", "json")
+	if err != nil {
+		t.Fatalf("kubectl get %s %s: %v\n%s", resource, name, err, out)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("parsing JSON for %s %s: %v", resource, name, err)
+	}
+	return result
+}
+
+func waitForResourceExists(t *testing.T, resource, name, namespace string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if kubectlGetExists(t, resource, name, namespace) {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for %s/%s to exist", resource, name)
+}
+
+func waitForResourceGone(t *testing.T, resource, name, namespace string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !kubectlGetExists(t, resource, name, namespace) {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for %s/%s to be deleted", resource, name)
+}
+
+func getCRConditions(t *testing.T, crName, namespace string) []map[string]any {
+	t.Helper()
+	obj := kubectlGetJSON(t, "llmbatchgateway", crName, namespace)
+
+	status, ok := obj["status"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	rawConds, ok := status["conditions"].([]any)
+	if !ok {
+		return nil
+	}
+
+	var conditions []map[string]any
+	for _, c := range rawConds {
+		if m, ok := c.(map[string]any); ok {
+			conditions = append(conditions, m)
+		}
+	}
+	return conditions
+}
+
+func findDeploymentByComponent(t *testing.T, namespace, instance, component string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	selector := fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=%s", instance, component)
+	out, err := kubectl(ctx, "get", "deployment", "-n", namespace, "-l", selector, "-o", "jsonpath={.items[0].metadata.name}")
+	if err != nil {
+		t.Fatalf("finding deployment with component=%s: %v\n%s", component, err, out)
+	}
+	name := string(out)
+	if name == "" {
+		t.Fatalf("no deployment found with labels instance=%s,component=%s", instance, component)
+	}
+	return name
+}
+
+func getDeploymentReplicas(t *testing.T, name, namespace string) int64 {
+	t.Helper()
+	obj := kubectlGetJSON(t, "deployment", name, namespace)
+
+	spec, ok := obj["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("deployment %s has no spec", name)
+	}
+	replicas, ok := spec["replicas"].(float64)
+	if !ok {
+		t.Fatalf("deployment %s has no spec.replicas", name)
+	}
+	return int64(replicas)
+}


### PR DESCRIPTION
## Description

Previously, when a CR spec change removed child resources (e.g. disabling grafana or monitoring), the stale resources remained in the cluster. The controller now diffs rendered objects against existing owned resources after each reconcile and deletes orphans. Missing CRDs are skipped gracefully.

## How Has This Been Tested?

`make test` — two new envtest tests:

- Disabling grafana on a CR deletes the dashboard ConfigMap, other resources unaffected
- Disabling grafana on one CR does not affect another CR's resources

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LLMBatchGateway specification validation before rendering with clear error reporting for configuration issues.
  * Implemented automatic cleanup of orphaned managed resources to prevent resource leaks.
  * Added support for digest-based container image references in addition to tag-based references.

* **Breaking Changes**
  * Removed namespace field from secret references; secrets must now be located in the operator namespace.

* **Documentation**
  * Added Design Document link to README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->