### PR TITLE
fix(api,controller): CRD conventions and controller correctness fixes

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,8 +1,8 @@
 domain: llm-d.ai
 layout:
 - go.kubebuilder.io/v4
-projectName: batch-gw-operator
-repo: github.com/llm-d-incubation/batch-gw-operator
+projectName: llm-d-batch-gateway-operator
+repo: github.com/opendatahub-io/llm-d-batch-gateway-operator
 version: "3"
 resources:
 - api:
@@ -12,5 +12,5 @@ resources:
   domain: llm-d.ai
   group: batch
   kind: LLMBatchGateway
-  path: github.com/llm-d-incubation/batch-gw-operator/api/v1alpha1
+  path: github.com/opendatahub-io/llm-d-batch-gateway-operator/api/v1alpha1
   version: v1alpha1

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -5,275 +5,531 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// LLMBatchGateway is the Schema for the llmbatchgateways API.
+// It represents a fully-managed deployment of the LLM-D batch gateway,
+// consisting of an API server, a request processor and a garbage-collector.
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=lbg
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
+// +kubebuilder:printcolumn:name="API-Ready",type="integer",JSONPath=`.status.componentStatus.apiServer.readyReplicas`
+// +kubebuilder:printcolumn:name="Proc-Ready",type="integer",JSONPath=`.status.componentStatus.processor.readyReplicas`
+// +kubebuilder:printcolumn:name="GC-Ready",type="integer",JSONPath=`.status.componentStatus.gc.readyReplicas`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type LLMBatchGateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   LLMBatchGatewaySpec   `json:"spec,omitempty"`
+	// Spec defines the desired state of LLMBatchGateway.
+	Spec LLMBatchGatewaySpec `json:"spec"`
+
+	// Status defines the observed state of LLMBatchGateway.
 	Status LLMBatchGatewayStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
+
+// LLMBatchGatewayList contains a list of LLMBatchGateway.
 type LLMBatchGatewayList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []LLMBatchGateway `json:"items"`
 }
 
+// LLMBatchGatewaySpec defines the desired state of the batch gateway deployment.
 type LLMBatchGatewaySpec struct {
+	// SecretRef references the Kubernetes Secret that holds runtime credentials
+	// (database URL, S3 keys, inference API key, etc.).
 	// +kubebuilder:validation:Required
 	SecretRef SecretReference `json:"secretRef"`
 
+	// DBBackend selects the database backend used for job state storage.
 	// +kubebuilder:validation:Enum=redis;postgresql;valkey
 	// +kubebuilder:default=postgresql
 	DBBackend string `json:"dbBackend,omitempty"`
 
+	// FileStorage configures the file storage backend used to persist batch
+	// input/output files. If omitted, S3 defaults are used.
 	FileStorage *FileStorageSpec `json:"fileStorage,omitempty"`
 
+	// APIServer configures the HTTP API server component.
 	// +kubebuilder:validation:Required
 	APIServer APIServerSpec `json:"apiServer"`
 
+	// Processor configures the request-processing worker component.
 	// +kubebuilder:validation:Required
 	Processor ProcessorSpec `json:"processor"`
 
+	// GC configures the garbage-collector component that expires old jobs and files.
+	// +kubebuilder:validation:Required
 	GC GCSpec `json:"gc"`
 
-	Monitoring *MonitoringSpec   `json:"monitoring,omitempty"`
-	Grafana    *GrafanaSpec      `json:"grafana,omitempty"`
-	TLS        *TLSSpec          `json:"tls,omitempty"`
-	HTTPRoute  *HTTPRouteSpec    `json:"httpRoute,omitempty"`
-	OTEL       *OTELSpec         `json:"otel,omitempty"`
+	// Monitoring enables Prometheus ServiceMonitor and PodMonitor resources.
+	Monitoring *MonitoringSpec `json:"monitoring,omitempty"`
+
+	// Grafana enables the bundled Grafana dashboard ConfigMap.
+	Grafana *GrafanaSpec `json:"grafana,omitempty"`
+
+	// TLS configures TLS termination for the API server.
+	TLS *TLSSpec `json:"tls,omitempty"`
+
+	// HTTPRoute configures a Gateway API HTTPRoute resource to expose the API server.
+	HTTPRoute *HTTPRouteSpec `json:"httpRoute,omitempty"`
+
+	// OTEL configures OpenTelemetry tracing for all components.
+	OTEL *OTELSpec `json:"otel,omitempty"`
+
+	// PrometheusRule configures a PrometheusRule resource with pre-built alerting rules.
 	PrometheusRule *PrometheusRuleSpec `json:"prometheusRule,omitempty"`
 }
 
+// SecretReference is a reference to a Kubernetes Secret in the same namespace
+// as the LLMBatchGateway CR.
 type SecretReference struct {
+	// Name is the name of the Secret.
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 }
 
 // --- File Storage ---
 
+// FileStorageSpec configures the file storage backend.
+// +kubebuilder:validation:XValidation:rule="self.type != 'fs' || has(self.fs)",message="fileStorage.fs must be set when type is 'fs'"
+// +kubebuilder:validation:XValidation:rule="self.type != 's3' || !has(self.fs)",message="fileStorage.fs must not be set when type is 's3'"
 type FileStorageSpec struct {
+	// Type selects the storage backend. Use 's3' for any S3-compatible object store,
+	// or 'fs' for a PersistentVolumeClaim-backed filesystem.
 	// +kubebuilder:validation:Enum=fs;s3
 	// +kubebuilder:default=s3
 	Type string `json:"type,omitempty"`
 
+	// S3 configures S3-compatible object storage. Required when type is 's3'.
 	S3 *S3StorageSpec `json:"s3,omitempty"`
+
+	// FS configures PVC-backed filesystem storage. Required when type is 'fs'.
 	FS *FSStorageSpec `json:"fs,omitempty"`
 
+	// Retry configures retry behaviour for transient file storage errors.
 	Retry *FileRetrySpec `json:"retry,omitempty"`
 }
 
+// S3StorageSpec configures S3-compatible object storage access.
+// The secret access key must be provided via spec.secretRef (key: s3-secret-access-key).
 type S3StorageSpec struct {
-	Region           string `json:"region,omitempty"`
-	Endpoint         string `json:"endpoint,omitempty"`
-	AccessKeyID      string `json:"accessKeyId,omitempty"`
-	Prefix           string `json:"prefix,omitempty"`
-	UsePathStyle     bool   `json:"usePathStyle,omitempty"`
-	AutoCreateBucket bool   `json:"autoCreateBucket,omitempty"`
+	// Region is the AWS region (e.g. "us-east-1").
+	// +kubebuilder:validation:MaxLength=253
+	Region string `json:"region,omitempty"`
+
+	// Endpoint overrides the S3 endpoint URL for non-AWS providers (e.g. MinIO).
+	// +kubebuilder:validation:MaxLength=2048
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// AccessKeyID is the S3 access key ID (non-sensitive). The corresponding
+	// secret access key must be provided via spec.secretRef.
+	// +optional
+	// +kubebuilder:validation:MaxLength=1024
+	AccessKeyID string `json:"accessKeyId,omitempty"`
+
+	// Prefix is an optional key prefix applied to all objects written to the bucket.
+	// +kubebuilder:validation:MaxLength=1024
+	Prefix string `json:"prefix,omitempty"`
+
+	// UsePathStyle forces path-style addressing (required by some S3-compatible stores).
+	UsePathStyle bool `json:"usePathStyle,omitempty"`
+
+	// AutoCreateBucket causes the operator to create the bucket if it does not exist.
+	AutoCreateBucket bool `json:"autoCreateBucket,omitempty"`
 }
 
+// FSStorageSpec configures PVC-backed filesystem storage.
 type FSStorageSpec struct {
+	// BasePath is the root directory inside the PVC where files are stored.
 	BasePath string `json:"basePath,omitempty"`
-	PVCName  string `json:"pvcName,omitempty"`
+
+	// PVCName is the name of the PersistentVolumeClaim to mount.
+	PVCName string `json:"pvcName,omitempty"`
 }
 
+// FileRetrySpec configures retry behaviour for transient file storage errors.
 type FileRetrySpec struct {
+	// MaxRetries is the maximum number of retry attempts.
 	// +kubebuilder:default=3
 	MaxRetries int32 `json:"maxRetries,omitempty"`
 
+	// InitialBackoff is the wait duration before the first retry (e.g. "1s").
 	// +kubebuilder:default="1s"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
 	InitialBackoff string `json:"initialBackoff,omitempty"`
 
+	// MaxBackoff is the maximum wait duration between retries (e.g. "10s").
 	// +kubebuilder:default="10s"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
 	MaxBackoff string `json:"maxBackoff,omitempty"`
 }
 
 // --- API Server ---
 
+// APIServerSpec configures the HTTP API server component.
 type APIServerSpec struct {
+	// Replicas is the desired number of API server pods.
+	// Setting this to 0 suspends the API server; the Ready condition will be False.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// Image is the container image for the API server (e.g. "ghcr.io/org/apiserver:v1.2.3").
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=1024
 	Image string `json:"image"`
 
+	// Resources defines CPU and memory requests/limits for the API server container.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// Config holds fine-grained API server configuration.
 	Config *APIServerConfigSpec `json:"config,omitempty"`
 }
 
+// APIServerConfigSpec holds fine-grained configuration for the API server process.
 type APIServerConfigSpec struct {
-	Port               string `json:"port,omitempty"`
-	ObservabilityPort  string `json:"observabilityPort,omitempty"`
-	ReadTimeoutSeconds int32  `json:"readTimeoutSeconds,omitempty"`
+	// Port is the TCP port the API server listens on.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	Port int32 `json:"port,omitempty"`
+
+	// ObservabilityPort is the TCP port that exposes metrics and health endpoints.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	ObservabilityPort int32 `json:"observabilityPort,omitempty"`
+
+	// ReadTimeoutSeconds is the maximum duration for reading an entire HTTP request.
+	ReadTimeoutSeconds int32 `json:"readTimeoutSeconds,omitempty"`
+
+	// WriteTimeoutSeconds is the maximum duration before timing out writes of the response.
 	WriteTimeoutSeconds int32 `json:"writeTimeoutSeconds,omitempty"`
-	IdleTimeoutSeconds int32  `json:"idleTimeoutSeconds,omitempty"`
 
+	// IdleTimeoutSeconds is the maximum amount of time to wait for the next request.
+	IdleTimeoutSeconds int32 `json:"idleTimeoutSeconds,omitempty"`
+
+	// BatchAPI configures the batch job submission endpoint behaviour.
 	BatchAPI *BatchAPIConfig `json:"batchAPI,omitempty"`
-	FileAPI  *FileAPIConfig  `json:"fileAPI,omitempty"`
 
+	// FileAPI configures the file upload/download endpoint behaviour.
+	FileAPI *FileAPIConfig `json:"fileAPI,omitempty"`
+
+	// EnablePprof enables the Go pprof profiling HTTP endpoints.
 	EnablePprof bool `json:"enablePprof,omitempty"`
 
+	// Logging configures log verbosity for the API server.
 	Logging *LoggingConfig `json:"logging,omitempty"`
 }
 
+// BatchAPIConfig configures the batch job submission API behaviour.
 type BatchAPIConfig struct {
-	EventTTLSeconds    int32    `json:"eventTTLSeconds,omitempty"`
+	// EventTTLSeconds is how long job events are retained before expiry.
+	EventTTLSeconds int32 `json:"eventTTLSeconds,omitempty"`
+
+	// PassThroughHeaders is a list of HTTP request headers forwarded to the inference backend.
+	// +kubebuilder:validation:items:MaxLength=256
 	PassThroughHeaders []string `json:"passThroughHeaders,omitempty"`
 }
 
+// FileAPIConfig configures the file upload/download API behaviour.
 type FileAPIConfig struct {
+	// DefaultExpirationSeconds is the default TTL for uploaded files.
 	DefaultExpirationSeconds int64 `json:"defaultExpirationSeconds,omitempty"`
-	MaxSizeBytes             int64 `json:"maxSizeBytes,omitempty"`
-	MaxLineCount             int64 `json:"maxLineCount,omitempty"`
+
+	// MaxSizeBytes is the maximum allowed size of a single uploaded file.
+	MaxSizeBytes int64 `json:"maxSizeBytes,omitempty"`
+
+	// MaxLineCount is the maximum number of lines allowed in a JSONL batch input file.
+	MaxLineCount int64 `json:"maxLineCount,omitempty"`
 }
 
+// LoggingConfig configures log verbosity.
 type LoggingConfig struct {
+	// Verbosity sets the log verbosity level (higher means more verbose).
 	Verbosity int32 `json:"verbosity,omitempty"`
 }
 
 // --- Processor ---
 
+// ProcessorSpec configures the request-processing worker component.
 type ProcessorSpec struct {
+	// Replicas is the desired number of processor pods.
+	// Setting this to 0 suspends the processor; the Ready condition will be False.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// Image is the container image for the processor (e.g. "ghcr.io/org/processor:v1.2.3").
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=1024
 	Image string `json:"image"`
 
+	// Resources defines CPU and memory requests/limits for the processor container.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	GlobalInferenceGateway *InferenceGatewaySpec            `json:"globalInferenceGateway,omitempty"`
-	ModelGateways          map[string]InferenceGatewaySpec   `json:"modelGateways,omitempty"`
+	// GlobalInferenceGateway is the default inference gateway used for all models
+	// unless overridden by a ModelGateways entry.
+	GlobalInferenceGateway *InferenceGatewaySpec `json:"globalInferenceGateway,omitempty"`
 
+	// ModelGateways maps model names to per-model inference gateway configurations,
+	// overriding GlobalInferenceGateway for those models.
+	ModelGateways map[string]InferenceGatewaySpec `json:"modelGateways,omitempty"`
+
+	// Config holds fine-grained processor configuration.
 	Config *ProcessorConfigSpec `json:"config,omitempty"`
 }
 
+// InferenceGatewaySpec configures a connection to an inference gateway.
 type InferenceGatewaySpec struct {
+	// URL is the base URL of the inference gateway (e.g. "http://gateway.svc:8000").
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=2048
 	URL string `json:"url"`
 
+	// RequestTimeout is the maximum time to wait for a single inference response (e.g. "5m").
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
+	// +kubebuilder:validation:MaxLength=32
 	RequestTimeout string `json:"requestTimeout,omitempty"`
-	MaxRetries     *int32 `json:"maxRetries,omitempty"`
-	InitialBackoff string `json:"initialBackoff,omitempty"`
-	MaxBackoff     string `json:"maxBackoff,omitempty"`
 
-	TLSInsecureSkipVerify bool   `json:"tlsInsecureSkipVerify,omitempty"`
-	TLSCACertFile         string `json:"tlsCaCertFile,omitempty"`
-	TLSClientCertFile     string `json:"tlsClientCertFile,omitempty"`
-	TLSClientKeyFile      string `json:"tlsClientKeyFile,omitempty"`
+	// MaxRetries is the maximum number of retry attempts on transient errors.
+	MaxRetries *int32 `json:"maxRetries,omitempty"`
+
+	// InitialBackoff is the wait duration before the first retry (e.g. "500ms").
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
+	// +kubebuilder:validation:MaxLength=32
+	InitialBackoff string `json:"initialBackoff,omitempty"`
+
+	// MaxBackoff is the maximum wait duration between retries (e.g. "30s").
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
+	// +kubebuilder:validation:MaxLength=32
+	MaxBackoff string `json:"maxBackoff,omitempty"`
+
+	// TLSInsecureSkipVerify disables TLS certificate verification. Not recommended for production.
+	TLSInsecureSkipVerify bool `json:"tlsInsecureSkipVerify,omitempty"`
+
+	// TLSCACertFile is the path to a custom CA certificate file for verifying the gateway's TLS certificate.
+	// +kubebuilder:validation:MaxLength=4096
+	TLSCACertFile string `json:"tlsCACertFile,omitempty"`
+
+	// TLSClientCertFile is the path to the client TLS certificate file for mutual TLS.
+	// +kubebuilder:validation:MaxLength=4096
+	TLSClientCertFile string `json:"tlsClientCertFile,omitempty"`
+
+	// TLSClientKeyFile is the path to the client TLS private key file for mutual TLS.
+	// +kubebuilder:validation:MaxLength=4096
+	TLSClientKeyFile string `json:"tlsClientKeyFile,omitempty"`
 }
 
+// ProcessorConfigSpec holds fine-grained configuration for the processor process.
 type ProcessorConfigSpec struct {
-	NumWorkers             int32  `json:"numWorkers,omitempty"`
-	GlobalConcurrency      int32  `json:"globalConcurrency,omitempty"`
-	PerModelMaxConcurrency int32  `json:"perModelMaxConcurrency,omitempty"`
-	RecoveryMaxConcurrency int32  `json:"recoveryMaxConcurrency,omitempty"`
-	InferenceObjective     string `json:"inferenceObjective,omitempty"`
+	// NumWorkers is the number of concurrent worker goroutines processing jobs.
+	NumWorkers int32 `json:"numWorkers,omitempty"`
 
+	// GlobalConcurrency is the maximum number of in-flight inference requests across all models.
+	GlobalConcurrency int32 `json:"globalConcurrency,omitempty"`
+
+	// PerModelMaxConcurrency is the maximum number of in-flight inference requests per model.
+	PerModelMaxConcurrency int32 `json:"perModelMaxConcurrency,omitempty"`
+
+	// RecoveryMaxConcurrency is the maximum concurrency for recovering in-progress jobs after restart.
+	RecoveryMaxConcurrency int32 `json:"recoveryMaxConcurrency,omitempty"`
+
+	// InferenceObjective specifies the scheduling objective (e.g. "throughput", "latency").
+	// +kubebuilder:validation:MaxLength=253
+	InferenceObjective string `json:"inferenceObjective,omitempty"`
+
+	// DefaultOutputExpirationSeconds is the TTL for job output files.
 	DefaultOutputExpirationSeconds int64 `json:"defaultOutputExpirationSeconds,omitempty"`
-	ProgressTTLSeconds             int64 `json:"progressTTLSeconds,omitempty"`
 
+	// ProgressTTLSeconds is how long in-progress job state is retained before being considered stale.
+	ProgressTTLSeconds int64 `json:"progressTTLSeconds,omitempty"`
+
+	// EnablePprof enables the Go pprof profiling HTTP endpoints.
 	EnablePprof bool `json:"enablePprof,omitempty"`
 
+	// Logging configures log verbosity for the processor.
 	Logging *LoggingConfig `json:"logging,omitempty"`
 }
 
 // --- GC ---
 
+// GCSpec configures the garbage-collector component.
 type GCSpec struct {
+	// Image is the container image for the GC (e.g. "ghcr.io/org/batch-gc:v1.2.3").
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=1024
 	Image string `json:"image"`
 
+	// Interval is how often the GC runs (e.g. "30m").
 	// +kubebuilder:default="30m"
+	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`
 	Interval string `json:"interval,omitempty"`
 
+	// Config holds fine-grained GC configuration.
 	Config *GCConfigSpec `json:"config,omitempty"`
 }
 
+// GCConfigSpec holds fine-grained configuration for the garbage-collector process.
 type GCConfigSpec struct {
-	DryRun         bool  `json:"dryRun,omitempty"`
+	// DryRun causes the GC to log what it would delete without actually deleting anything.
+	DryRun bool `json:"dryRun,omitempty"`
+
+	// MaxConcurrency is the maximum number of deletion operations performed in parallel.
 	MaxConcurrency int32 `json:"maxConcurrency,omitempty"`
 
+	// Logging configures log verbosity for the GC.
 	Logging *LoggingConfig `json:"logging,omitempty"`
 }
 
 // --- Observability ---
 
+// MonitoringSpec enables Prometheus monitoring resources.
 type MonitoringSpec struct {
+	// Enabled controls whether a ServiceMonitor and PodMonitor are created for each component.
 	Enabled bool `json:"enabled,omitempty"`
 }
 
+// GrafanaSpec enables the bundled Grafana dashboard.
 type GrafanaSpec struct {
+	// Enabled controls whether a Grafana dashboard ConfigMap is created.
 	Enabled bool `json:"enabled,omitempty"`
 }
 
+// PrometheusRuleSpec configures a PrometheusRule resource with pre-built alerting rules.
 type PrometheusRuleSpec struct {
-	Enabled bool              `json:"enabled,omitempty"`
-	Labels  map[string]string `json:"labels,omitempty"`
+	// Enabled controls whether a PrometheusRule resource is created.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// Labels are additional labels applied to the PrometheusRule resource,
+	// used to match Prometheus operator rule selectors.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
+// OTELSpec configures OpenTelemetry tracing for all components.
 type OTELSpec struct {
-	Endpoint           string `json:"endpoint,omitempty"`
-	Insecure           bool   `json:"insecure,omitempty"`
-	Sampler            string `json:"sampler,omitempty"`
-	SamplerArg         string `json:"samplerArg,omitempty"`
-	RedisTracing       bool   `json:"redisTracing,omitempty"`
-	PostgresqlTracing  bool   `json:"postgresqlTracing,omitempty"`
+	// Endpoint is the OTLP gRPC or HTTP endpoint (e.g. "http://collector:4317").
+	// +kubebuilder:validation:MaxLength=2048
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// Insecure disables TLS for the OTLP connection.
+	Insecure bool `json:"insecure,omitempty"`
+
+	// Sampler is the OTEL sampler type (e.g. "parentbased_traceidratio").
+	// +kubebuilder:validation:MaxLength=253
+	Sampler string `json:"sampler,omitempty"`
+
+	// SamplerArg is the argument passed to the sampler (e.g. "0.1" for 10% sampling).
+	// +kubebuilder:validation:MaxLength=253
+	SamplerArg string `json:"samplerArg,omitempty"`
+
+	// RedisTracing enables tracing of Redis operations.
+	RedisTracing bool `json:"redisTracing,omitempty"`
+
+	// PostgresqlTracing enables tracing of PostgreSQL operations.
+	PostgresqlTracing bool `json:"postgresqlTracing,omitempty"`
 }
 
 // --- TLS ---
 
+// TLSSpec configures TLS termination for the API server.
+// +kubebuilder:validation:XValidation:rule="!self.enabled || self.secretName != ” || has(self.certManager)",message="tls.secretName or tls.certManager must be set when tls.enabled is true"
 type TLSSpec struct {
-	Enabled     bool             `json:"enabled,omitempty"`
-	SecretName  string           `json:"secretName,omitempty"`
+	// Enabled controls whether TLS termination is configured for the API server.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// SecretName is the name of an existing TLS Secret (type kubernetes.io/tls)
+	// containing the certificate and key. Mutually exclusive with certManager.
+	// +kubebuilder:validation:MaxLength=253
+	SecretName string `json:"secretName,omitempty"`
+
+	// CertManager configures automatic certificate provisioning via cert-manager.
+	// Mutually exclusive with secretName.
 	CertManager *CertManagerSpec `json:"certManager,omitempty"`
 }
 
+// CertManagerSpec configures automatic certificate provisioning via cert-manager.
 type CertManagerSpec struct {
-	IssuerName string   `json:"issuerName,omitempty"`
-	IssuerKind string   `json:"issuerKind,omitempty"`
-	DNSNames   []string `json:"dnsNames,omitempty"`
+	// IssuerName is the name of the cert-manager Issuer or ClusterIssuer.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=253
+	IssuerName string `json:"issuerName"`
+
+	// IssuerKind is the kind of the cert-manager issuer resource ("Issuer" or "ClusterIssuer").
+	IssuerKind string `json:"issuerKind,omitempty"`
+
+	// DNSNames is the list of DNS SANs to include in the issued certificate.
+	// +kubebuilder:validation:items:MaxLength=253
+	DNSNames []string `json:"dnsNames,omitempty"`
 }
 
 // --- HTTPRoute ---
 
+// HTTPRouteSpec configures a Gateway API HTTPRoute to expose the API server.
 type HTTPRouteSpec struct {
-	Enabled     bool              `json:"enabled,omitempty"`
+	// Enabled controls whether an HTTPRoute resource is created.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// Annotations are extra annotations applied to the HTTPRoute resource.
 	Annotations map[string]string `json:"annotations,omitempty"`
-	ParentRefs  []ParentReference `json:"parentRefs,omitempty"`
+
+	// ParentRefs is the list of Gateways this HTTPRoute should attach to.
+	// +listType=map
+	// +listMapKey=name
+	ParentRefs []ParentReference `json:"parentRefs,omitempty"`
 }
 
+// ParentReference identifies a Gateway to which an HTTPRoute should attach.
 type ParentReference struct {
-	Name        string `json:"name"`
-	Namespace   string `json:"namespace,omitempty"`
+	// Name is the name of the Gateway resource.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=253
+	Name string `json:"name"`
+
+	// Namespace is the namespace of the Gateway resource. Defaults to the HTTPRoute's namespace.
+	// +kubebuilder:validation:MaxLength=63
+	Namespace string `json:"namespace,omitempty"`
+
+	// SectionName is the name of a specific listener on the Gateway to attach to.
+	// +kubebuilder:validation:MaxLength=253
 	SectionName string `json:"sectionName,omitempty"`
 }
 
 // --- Status ---
 
+// LLMBatchGatewayStatus defines the observed state of LLMBatchGateway.
 type LLMBatchGatewayStatus struct {
-	ObservedGeneration int64              `json:"observedGeneration,omitempty"`
-	Conditions         []metav1.Condition `json:"conditions,omitempty"`
-	ComponentStatus    *ComponentStatus   `json:"componentStatus,omitempty"`
+	// ObservedGeneration is the .metadata.generation that was last processed by the controller.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// Conditions represent the latest available observations of the LLMBatchGateway's state.
+	// Known condition types: Ready, APIServerAvailable, ProcessorAvailable, GCAvailable.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// ComponentStatus reports the replica counts for each managed component.
+	ComponentStatus *ComponentStatus `json:"componentStatus,omitempty"`
 }
 
+// ComponentStatus reports the replica status of each managed component.
 type ComponentStatus struct {
+	// APIServer reports the replica status of the API server Deployment.
 	APIServer *ComponentReplicaStatus `json:"apiServer,omitempty"`
+
+	// Processor reports the replica status of the processor Deployment.
 	Processor *ComponentReplicaStatus `json:"processor,omitempty"`
-	GC        *ComponentReplicaStatus `json:"gc,omitempty"`
+
+	// GC reports the replica status of the garbage-collector Deployment.
+	GC *ComponentReplicaStatus `json:"gc,omitempty"`
 }
 
+// ComponentReplicaStatus reports the desired and ready replica counts for a Deployment.
 type ComponentReplicaStatus struct {
-	Replicas      int32 `json:"replicas"`
+	// Replicas is the total number of non-terminated pods.
+	Replicas int32 `json:"replicas"`
+
+	// ReadyReplicas is the number of pods that have passed their readiness checks.
 	ReadyReplicas int32 `json:"readyReplicas"`
 }
 

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -435,7 +435,8 @@ type OTELSpec struct {
 // --- TLS ---
 
 // TLSSpec configures TLS termination for the API server.
-// +kubebuilder:validation:XValidation:rule="!self.enabled || self.secretName != ” || has(self.certManager)",message="tls.secretName or tls.certManager must be set when tls.enabled is true"
+// +kubebuilder:validation:XValidation:rule="!self.enabled || self.secretName != '' || has(self.certManager)",message="tls.secretName or tls.certManager must be set when tls.enabled is true"
+// +kubebuilder:validation:XValidation:rule="!(self.secretName != '' && has(self.certManager))",message="tls.secretName and tls.certManager are mutually exclusive"
 type TLSSpec struct {
 	// Enabled controls whether TLS termination is configured for the API server.
 	Enabled bool `json:"enabled,omitempty"`
@@ -451,13 +452,16 @@ type TLSSpec struct {
 }
 
 // CertManagerSpec configures automatic certificate provisioning via cert-manager.
+// +kubebuilder:validation:XValidation:rule="self.issuerName != ''",message="certManager.issuerName must be set"
 type CertManagerSpec struct {
 	// IssuerName is the name of the cert-manager Issuer or ClusterIssuer.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=253
 	IssuerName string `json:"issuerName"`
 
-	// IssuerKind is the kind of the cert-manager issuer resource ("Issuer" or "ClusterIssuer").
+	// IssuerKind is the kind of the cert-manager issuer resource.
+	// +kubebuilder:validation:Enum=Issuer;ClusterIssuer
+	// +kubebuilder:default=ClusterIssuer
 	IssuerKind string `json:"issuerKind,omitempty"`
 
 	// DNSNames is the list of DNS SANs to include in the issued certificate.

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -95,19 +95,13 @@ type SecretReference struct {
 // --- File Storage ---
 
 // FileStorageSpec configures the file storage backend.
-// +kubebuilder:validation:XValidation:rule="self.type != 'fs' || has(self.fs)",message="fileStorage.fs must be set when type is 'fs'"
-// +kubebuilder:validation:XValidation:rule="self.type != 's3' || !has(self.fs)",message="fileStorage.fs must not be set when type is 's3'"
+// Exactly one of s3 or fs must be set.
+// +kubebuilder:validation:XValidation:rule="has(self.s3) != has(self.fs)",message="exactly one of fileStorage.s3 or fileStorage.fs must be set"
 type FileStorageSpec struct {
-	// Type selects the storage backend. Use 's3' for any S3-compatible object store,
-	// or 'fs' for a PersistentVolumeClaim-backed filesystem.
-	// +kubebuilder:validation:Enum=fs;s3
-	// +kubebuilder:default=s3
-	Type string `json:"type,omitempty"`
-
-	// S3 configures S3-compatible object storage. Required when type is 's3'.
+	// S3 configures S3-compatible object storage. Mutually exclusive with fs.
 	S3 *S3StorageSpec `json:"s3,omitempty"`
 
-	// FS configures PVC-backed filesystem storage. Required when type is 'fs'.
+	// FS configures PVC-backed filesystem storage. Mutually exclusive with s3.
 	FS *FSStorageSpec `json:"fs,omitempty"`
 
 	// Retry configures retry behaviour for transient file storage errors.

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -139,10 +139,12 @@ type S3StorageSpec struct {
 // FSStorageSpec configures PVC-backed filesystem storage.
 type FSStorageSpec struct {
 	// BasePath is the root directory inside the PVC where files are stored.
+	// +kubebuilder:validation:MaxLength=4096
 	BasePath string `json:"basePath,omitempty"`
 
-	// PVCName is the name of the PersistentVolumeClaim to mount.
-	PVCName string `json:"pvcName,omitempty"`
+	// ClaimName is the name of the PersistentVolumeClaim to mount.
+	// +kubebuilder:validation:MaxLength=253
+	ClaimName string `json:"claimName,omitempty"`
 }
 
 // FileRetrySpec configures retry behaviour for transient file storage errors.

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -12,863 +12,898 @@ spec:
     listKind: LLMBatchGatewayList
     plural: llmbatchgateways
     shortNames:
-      - lbg
+    - lbg
     singular: llmbatchgateway
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=="Ready")].status
-          name: Ready
-          type: string
-        - jsonPath: .status.componentStatus.apiServer.readyReplicas
-          name: API-Ready
-          type: integer
-        - jsonPath: .status.componentStatus.processor.readyReplicas
-          name: Proc-Ready
-          type: integer
-        - jsonPath: .status.componentStatus.gc.readyReplicas
-          name: GC-Ready
-          type: integer
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: |-
-            LLMBatchGateway is the Schema for the llmbatchgateways API.
-            It represents a fully-managed deployment of the LLM-D batch gateway,
-            consisting of an API server, a request processor and a garbage-collector.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec defines the desired state of LLMBatchGateway.
-              properties:
-                apiServer:
-                  description: APIServer configures the HTTP API server component.
-                  properties:
-                    config:
-                      description: Config holds fine-grained API server configuration.
-                      properties:
-                        batchAPI:
-                          description: BatchAPI configures the batch job submission endpoint behaviour.
-                          properties:
-                            eventTTLSeconds:
-                              description: EventTTLSeconds is how long job events are retained before expiry.
-                              format: int32
-                              type: integer
-                            passThroughHeaders:
-                              description: PassThroughHeaders is a list of HTTP request headers forwarded to
-                                the inference backend.
-                              items:
-                                maxLength: 256
-                                type: string
-                              type: array
-                          type: object
-                        enablePprof:
-                          description: EnablePprof enables the Go pprof profiling HTTP endpoints.
-                          type: boolean
-                        fileAPI:
-                          description: FileAPI configures the file upload/download endpoint behaviour.
-                          properties:
-                            defaultExpirationSeconds:
-                              description: DefaultExpirationSeconds is the default TTL for uploaded files.
-                              format: int64
-                              type: integer
-                            maxLineCount:
-                              description: MaxLineCount is the maximum number of lines allowed in a JSONL
-                                batch input file.
-                              format: int64
-                              type: integer
-                            maxSizeBytes:
-                              description: MaxSizeBytes is the maximum allowed size of a single uploaded file.
-                              format: int64
-                              type: integer
-                          type: object
-                        idleTimeoutSeconds:
-                          description: IdleTimeoutSeconds is the maximum amount of time to wait for the
-                            next request.
-                          format: int32
-                          type: integer
-                        logging:
-                          description: Logging configures log verbosity for the API server.
-                          properties:
-                            verbosity:
-                              description: Verbosity sets the log verbosity level (higher means more verbose).
-                              format: int32
-                              type: integer
-                          type: object
-                        observabilityPort:
-                          description: ObservabilityPort is the TCP port that exposes metrics and health
-                            endpoints.
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
-                        port:
-                          description: Port is the TCP port the API server listens on.
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
-                        readTimeoutSeconds:
-                          description: ReadTimeoutSeconds is the maximum duration for reading an entire
-                            HTTP request.
-                          format: int32
-                          type: integer
-                        writeTimeoutSeconds:
-                          description: WriteTimeoutSeconds is the maximum duration before timing out
-                            writes of the response.
-                          format: int32
-                          type: integer
-                      type: object
-                    image:
-                      description: Image is the container image for the API server (e.g.
-                        "ghcr.io/org/apiserver:v1.2.3").
-                      maxLength: 1024
-                      type: string
-                    replicas:
-                      default: 1
-                      description: |-
-                        Replicas is the desired number of API server pods.
-                        Setting this to 0 suspends the API server; the Ready condition will be False.
-                      format: int32
-                      minimum: 0
-                      type: integer
-                    resources:
-                      description: Resources defines CPU and memory requests/limits for the API server
-                        container.
-                      properties:
-                        claims:
-                          description: |-
-                            Claims lists the names of resources, defined in spec.resourceClaims,
-                            that are used by this container.
-
-                            This field depends on the
-                            DynamicResourceAllocation feature gate.
-
-                            This field is immutable. It can only be set for containers.
-                          items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                            properties:
-                              name:
-                                description: |-
-                                  Name must match the name of one entry in pod.spec.resourceClaims of
-                                  the Pod where this field is used. It makes that resource available
-                                  inside a container.
-                                type: string
-                              request:
-                                description: |-
-                                  Request is the name chosen for a request in the referenced claim.
-                                  If empty, everything from the claim is made available, otherwise
-                                  only the result of this request.
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                      type: object
-                  required:
-                    - image
-                  type: object
-                dbBackend:
-                  default: postgresql
-                  description: DBBackend selects the database backend used for job state storage.
-                  enum:
-                    - redis
-                    - postgresql
-                    - valkey
-                  type: string
-                fileStorage:
-                  description: |-
-                    FileStorage configures the file storage backend used to persist batch
-                    input/output files. If omitted, S3 defaults are used.
-                  properties:
-                    fs:
-                      description: FS configures PVC-backed filesystem storage. Required when type is
-                        'fs'.
-                      properties:
-                        basePath:
-                          description: BasePath is the root directory inside the PVC where files are
-                            stored.
-                          type: string
-                        pvcName:
-                          description: PVCName is the name of the PersistentVolumeClaim to mount.
-                          type: string
-                      type: object
-                    retry:
-                      description: Retry configures retry behaviour for transient file storage errors.
-                      properties:
-                        initialBackoff:
-                          default: 1s
-                          description: InitialBackoff is the wait duration before the first retry (e.g.
-                            "1s").
-                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                          type: string
-                        maxBackoff:
-                          default: 10s
-                          description: MaxBackoff is the maximum wait duration between retries (e.g.
-                            "10s").
-                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                          type: string
-                        maxRetries:
-                          default: 3
-                          description: MaxRetries is the maximum number of retry attempts.
-                          format: int32
-                          type: integer
-                      type: object
-                    s3:
-                      description: S3 configures S3-compatible object storage. Required when type is
-                        's3'.
-                      properties:
-                        accessKeyId:
-                          description: |-
-                            AccessKeyID is the S3 access key ID (non-sensitive). The corresponding
-                            secret access key must be provided via spec.secretRef.
-                          maxLength: 1024
-                          type: string
-                        autoCreateBucket:
-                          description: AutoCreateBucket causes the operator to create the bucket if it
-                            does not exist.
-                          type: boolean
-                        endpoint:
-                          description: Endpoint overrides the S3 endpoint URL for non-AWS providers (e.g.
-                            MinIO).
-                          maxLength: 2048
-                          type: string
-                        prefix:
-                          description: Prefix is an optional key prefix applied to all objects written to
-                            the bucket.
-                          maxLength: 1024
-                          type: string
-                        region:
-                          description: Region is the AWS region (e.g. "us-east-1").
-                          maxLength: 253
-                          type: string
-                        usePathStyle:
-                          description: UsePathStyle forces path-style addressing (required by some
-                            S3-compatible stores).
-                          type: boolean
-                      type: object
-                    type:
-                      default: s3
-                      description: |-
-                        Type selects the storage backend. Use 's3' for any S3-compatible object store,
-                        or 'fs' for a PersistentVolumeClaim-backed filesystem.
-                      enum:
-                        - fs
-                        - s3
-                      type: string
-                  type: object
-                  x-kubernetes-validations:
-                    - message: fileStorage.fs must be set when type is 'fs'
-                      rule: self.type != 'fs' || has(self.fs)
-                    - message: fileStorage.fs must not be set when type is 's3'
-                      rule: self.type != 's3' || !has(self.fs)
-                gc:
-                  description: GC configures the garbage-collector component that expires old jobs
-                    and files.
-                  properties:
-                    config:
-                      description: Config holds fine-grained GC configuration.
-                      properties:
-                        dryRun:
-                          description: DryRun causes the GC to log what it would delete without actually
-                            deleting anything.
-                          type: boolean
-                        logging:
-                          description: Logging configures log verbosity for the GC.
-                          properties:
-                            verbosity:
-                              description: Verbosity sets the log verbosity level (higher means more verbose).
-                              format: int32
-                              type: integer
-                          type: object
-                        maxConcurrency:
-                          description: MaxConcurrency is the maximum number of deletion operations
-                            performed in parallel.
-                          format: int32
-                          type: integer
-                      type: object
-                    image:
-                      description: Image is the container image for the GC (e.g.
-                        "ghcr.io/org/batch-gc:v1.2.3").
-                      maxLength: 1024
-                      type: string
-                    interval:
-                      default: 30m
-                      description: Interval is how often the GC runs (e.g. "30m").
-                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                      type: string
-                  required:
-                    - image
-                  type: object
-                grafana:
-                  description: Grafana enables the bundled Grafana dashboard ConfigMap.
-                  properties:
-                    enabled:
-                      description: Enabled controls whether a Grafana dashboard ConfigMap is created.
-                      type: boolean
-                  type: object
-                httpRoute:
-                  description: HTTPRoute configures a Gateway API HTTPRoute resource to expose the
-                    API server.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations are extra annotations applied to the HTTPRoute
-                        resource.
-                      type: object
-                    enabled:
-                      description: Enabled controls whether an HTTPRoute resource is created.
-                      type: boolean
-                    parentRefs:
-                      description: ParentRefs is the list of Gateways this HTTPRoute should attach to.
-                      items:
-                        description: ParentReference identifies a Gateway to which an HTTPRoute should
-                          attach.
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.componentStatus.apiServer.readyReplicas
+      name: API-Ready
+      type: integer
+    - jsonPath: .status.componentStatus.processor.readyReplicas
+      name: Proc-Ready
+      type: integer
+    - jsonPath: .status.componentStatus.gc.readyReplicas
+      name: GC-Ready
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          LLMBatchGateway is the Schema for the llmbatchgateways API.
+          It represents a fully-managed deployment of the LLM-D batch gateway,
+          consisting of an API server, a request processor and a garbage-collector.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of LLMBatchGateway.
+            properties:
+              apiServer:
+                description: APIServer configures the HTTP API server component.
+                properties:
+                  config:
+                    description: Config holds fine-grained API server configuration.
+                    properties:
+                      batchAPI:
+                        description: BatchAPI configures the batch job submission
+                          endpoint behaviour.
                         properties:
-                          name:
-                            description: Name is the name of the Gateway resource.
-                            maxLength: 253
-                            type: string
-                          namespace:
-                            description: Namespace is the namespace of the Gateway resource. Defaults to the
-                              HTTPRoute's namespace.
-                            maxLength: 63
-                            type: string
-                          sectionName:
-                            description: SectionName is the name of a specific listener on the Gateway to
-                              attach to.
-                            maxLength: 253
-                            type: string
-                        required:
-                          - name
+                          eventTTLSeconds:
+                            description: EventTTLSeconds is how long job events are
+                              retained before expiry.
+                            format: int32
+                            type: integer
+                          passThroughHeaders:
+                            description: PassThroughHeaders is a list of HTTP request
+                              headers forwarded to the inference backend.
+                            items:
+                              maxLength: 256
+                              type: string
+                            type: array
                         type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
+                      enablePprof:
+                        description: EnablePprof enables the Go pprof profiling HTTP
+                          endpoints.
+                        type: boolean
+                      fileAPI:
+                        description: FileAPI configures the file upload/download endpoint
+                          behaviour.
+                        properties:
+                          defaultExpirationSeconds:
+                            description: DefaultExpirationSeconds is the default TTL
+                              for uploaded files.
+                            format: int64
+                            type: integer
+                          maxLineCount:
+                            description: MaxLineCount is the maximum number of lines
+                              allowed in a JSONL batch input file.
+                            format: int64
+                            type: integer
+                          maxSizeBytes:
+                            description: MaxSizeBytes is the maximum allowed size
+                              of a single uploaded file.
+                            format: int64
+                            type: integer
+                        type: object
+                      idleTimeoutSeconds:
+                        description: IdleTimeoutSeconds is the maximum amount of time
+                          to wait for the next request.
+                        format: int32
+                        type: integer
+                      logging:
+                        description: Logging configures log verbosity for the API
+                          server.
+                        properties:
+                          verbosity:
+                            description: Verbosity sets the log verbosity level (higher
+                              means more verbose).
+                            format: int32
+                            type: integer
+                        type: object
+                      observabilityPort:
+                        description: ObservabilityPort is the TCP port that exposes
+                          metrics and health endpoints.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      port:
+                        description: Port is the TCP port the API server listens on.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      readTimeoutSeconds:
+                        description: ReadTimeoutSeconds is the maximum duration for
+                          reading an entire HTTP request.
+                        format: int32
+                        type: integer
+                      writeTimeoutSeconds:
+                        description: WriteTimeoutSeconds is the maximum duration before
+                          timing out writes of the response.
+                        format: int32
+                        type: integer
+                    type: object
+                  image:
+                    description: Image is the container image for the API server (e.g.
+                      "ghcr.io/org/apiserver:v1.2.3").
+                    maxLength: 1024
+                    type: string
+                  replicas:
+                    default: 1
+                    description: |-
+                      Replicas is the desired number of API server pods.
+                      Setting this to 0 suspends the API server; the Ready condition will be False.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources defines CPU and memory requests/limits
+                      for the API server container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
                         - name
-                      x-kubernetes-list-type: map
-                  type: object
-                monitoring:
-                  description: Monitoring enables Prometheus ServiceMonitor and PodMonitor
-                    resources.
-                  properties:
-                    enabled:
-                      description: Enabled controls whether a ServiceMonitor and PodMonitor are
-                        created for each component.
-                      type: boolean
-                  type: object
-                otel:
-                  description: OTEL configures OpenTelemetry tracing for all components.
-                  properties:
-                    endpoint:
-                      description: Endpoint is the OTLP gRPC or HTTP endpoint (e.g.
-                        "http://collector:4317").
-                      maxLength: 2048
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              dbBackend:
+                default: postgresql
+                description: DBBackend selects the database backend used for job state
+                  storage.
+                enum:
+                - redis
+                - postgresql
+                - valkey
+                type: string
+              fileStorage:
+                description: |-
+                  FileStorage configures the file storage backend used to persist batch
+                  input/output files. If omitted, S3 defaults are used.
+                properties:
+                  fs:
+                    description: FS configures PVC-backed filesystem storage. Required
+                      when type is 'fs'.
+                    properties:
+                      basePath:
+                        description: BasePath is the root directory inside the PVC
+                          where files are stored.
+                        type: string
+                      pvcName:
+                        description: PVCName is the name of the PersistentVolumeClaim
+                          to mount.
+                        type: string
+                    type: object
+                  retry:
+                    description: Retry configures retry behaviour for transient file
+                      storage errors.
+                    properties:
+                      initialBackoff:
+                        default: 1s
+                        description: InitialBackoff is the wait duration before the
+                          first retry (e.g. "1s").
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      maxBackoff:
+                        default: 10s
+                        description: MaxBackoff is the maximum wait duration between
+                          retries (e.g. "10s").
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      maxRetries:
+                        default: 3
+                        description: MaxRetries is the maximum number of retry attempts.
+                        format: int32
+                        type: integer
+                    type: object
+                  s3:
+                    description: S3 configures S3-compatible object storage. Required
+                      when type is 's3'.
+                    properties:
+                      accessKeyId:
+                        description: |-
+                          AccessKeyID is the S3 access key ID (non-sensitive). The corresponding
+                          secret access key must be provided via spec.secretRef.
+                        maxLength: 1024
+                        type: string
+                      autoCreateBucket:
+                        description: AutoCreateBucket causes the operator to create
+                          the bucket if it does not exist.
+                        type: boolean
+                      endpoint:
+                        description: Endpoint overrides the S3 endpoint URL for non-AWS
+                          providers (e.g. MinIO).
+                        maxLength: 2048
+                        type: string
+                      prefix:
+                        description: Prefix is an optional key prefix applied to all
+                          objects written to the bucket.
+                        maxLength: 1024
+                        type: string
+                      region:
+                        description: Region is the AWS region (e.g. "us-east-1").
+                        maxLength: 253
+                        type: string
+                      usePathStyle:
+                        description: UsePathStyle forces path-style addressing (required
+                          by some S3-compatible stores).
+                        type: boolean
+                    type: object
+                  type:
+                    default: s3
+                    description: |-
+                      Type selects the storage backend. Use 's3' for any S3-compatible object store,
+                      or 'fs' for a PersistentVolumeClaim-backed filesystem.
+                    enum:
+                    - fs
+                    - s3
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: fileStorage.fs must be set when type is 'fs'
+                  rule: self.type != 'fs' || has(self.fs)
+                - message: fileStorage.fs must not be set when type is 's3'
+                  rule: self.type != 's3' || !has(self.fs)
+              gc:
+                description: GC configures the garbage-collector component that expires
+                  old jobs and files.
+                properties:
+                  config:
+                    description: Config holds fine-grained GC configuration.
+                    properties:
+                      dryRun:
+                        description: DryRun causes the GC to log what it would delete
+                          without actually deleting anything.
+                        type: boolean
+                      logging:
+                        description: Logging configures log verbosity for the GC.
+                        properties:
+                          verbosity:
+                            description: Verbosity sets the log verbosity level (higher
+                              means more verbose).
+                            format: int32
+                            type: integer
+                        type: object
+                      maxConcurrency:
+                        description: MaxConcurrency is the maximum number of deletion
+                          operations performed in parallel.
+                        format: int32
+                        type: integer
+                    type: object
+                  image:
+                    description: Image is the container image for the GC (e.g. "ghcr.io/org/batch-gc:v1.2.3").
+                    maxLength: 1024
+                    type: string
+                  interval:
+                    default: 30m
+                    description: Interval is how often the GC runs (e.g. "30m").
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                required:
+                - image
+                type: object
+              grafana:
+                description: Grafana enables the bundled Grafana dashboard ConfigMap.
+                properties:
+                  enabled:
+                    description: Enabled controls whether a Grafana dashboard ConfigMap
+                      is created.
+                    type: boolean
+                type: object
+              httpRoute:
+                description: HTTPRoute configures a Gateway API HTTPRoute resource
+                  to expose the API server.
+                properties:
+                  annotations:
+                    additionalProperties:
                       type: string
-                    insecure:
-                      description: Insecure disables TLS for the OTLP connection.
-                      type: boolean
-                    postgresqlTracing:
-                      description: PostgresqlTracing enables tracing of PostgreSQL operations.
-                      type: boolean
-                    redisTracing:
-                      description: RedisTracing enables tracing of Redis operations.
-                      type: boolean
-                    sampler:
-                      description: Sampler is the OTEL sampler type (e.g. "parentbased_traceidratio").
-                      maxLength: 253
-                      type: string
-                    samplerArg:
-                      description: SamplerArg is the argument passed to the sampler (e.g. "0.1" for
-                        10% sampling).
-                      maxLength: 253
-                      type: string
-                  type: object
-                processor:
-                  description: Processor configures the request-processing worker component.
-                  properties:
-                    config:
-                      description: Config holds fine-grained processor configuration.
+                    description: Annotations are extra annotations applied to the
+                      HTTPRoute resource.
+                    type: object
+                  enabled:
+                    description: Enabled controls whether an HTTPRoute resource is
+                      created.
+                    type: boolean
+                  parentRefs:
+                    description: ParentRefs is the list of Gateways this HTTPRoute
+                      should attach to.
+                    items:
+                      description: ParentReference identifies a Gateway to which an
+                        HTTPRoute should attach.
                       properties:
-                        defaultOutputExpirationSeconds:
-                          description: DefaultOutputExpirationSeconds is the TTL for job output files.
-                          format: int64
-                          type: integer
-                        enablePprof:
-                          description: EnablePprof enables the Go pprof profiling HTTP endpoints.
-                          type: boolean
-                        globalConcurrency:
-                          description: GlobalConcurrency is the maximum number of in-flight inference
-                            requests across all models.
-                          format: int32
-                          type: integer
-                        inferenceObjective:
-                          description: InferenceObjective specifies the scheduling objective (e.g.
-                            "throughput", "latency").
+                        name:
+                          description: Name is the name of the Gateway resource.
                           maxLength: 253
                           type: string
-                        logging:
-                          description: Logging configures log verbosity for the processor.
-                          properties:
-                            verbosity:
-                              description: Verbosity sets the log verbosity level (higher means more verbose).
-                              format: int32
-                              type: integer
-                          type: object
-                        numWorkers:
-                          description: NumWorkers is the number of concurrent worker goroutines processing
-                            jobs.
-                          format: int32
-                          type: integer
-                        perModelMaxConcurrency:
-                          description: PerModelMaxConcurrency is the maximum number of in-flight inference
-                            requests per model.
-                          format: int32
-                          type: integer
-                        progressTTLSeconds:
-                          description: ProgressTTLSeconds is how long in-progress job state is retained
-                            before being considered stale.
-                          format: int64
-                          type: integer
-                        recoveryMaxConcurrency:
-                          description: RecoveryMaxConcurrency is the maximum concurrency for recovering
-                            in-progress jobs after restart.
-                          format: int32
-                          type: integer
+                        namespace:
+                          description: Namespace is the namespace of the Gateway resource.
+                            Defaults to the HTTPRoute's namespace.
+                          maxLength: 63
+                          type: string
+                        sectionName:
+                          description: SectionName is the name of a specific listener
+                            on the Gateway to attach to.
+                          maxLength: 253
+                          type: string
+                      required:
+                      - name
                       type: object
-                    globalInferenceGateway:
-                      description: |-
-                        GlobalInferenceGateway is the default inference gateway used for all models
-                        unless overridden by a ModelGateways entry.
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
+              monitoring:
+                description: Monitoring enables Prometheus ServiceMonitor and PodMonitor
+                  resources.
+                properties:
+                  enabled:
+                    description: Enabled controls whether a ServiceMonitor and PodMonitor
+                      are created for each component.
+                    type: boolean
+                type: object
+              otel:
+                description: OTEL configures OpenTelemetry tracing for all components.
+                properties:
+                  endpoint:
+                    description: Endpoint is the OTLP gRPC or HTTP endpoint (e.g.
+                      "http://collector:4317").
+                    maxLength: 2048
+                    type: string
+                  insecure:
+                    description: Insecure disables TLS for the OTLP connection.
+                    type: boolean
+                  postgresqlTracing:
+                    description: PostgresqlTracing enables tracing of PostgreSQL operations.
+                    type: boolean
+                  redisTracing:
+                    description: RedisTracing enables tracing of Redis operations.
+                    type: boolean
+                  sampler:
+                    description: Sampler is the OTEL sampler type (e.g. "parentbased_traceidratio").
+                    maxLength: 253
+                    type: string
+                  samplerArg:
+                    description: SamplerArg is the argument passed to the sampler
+                      (e.g. "0.1" for 10% sampling).
+                    maxLength: 253
+                    type: string
+                type: object
+              processor:
+                description: Processor configures the request-processing worker component.
+                properties:
+                  config:
+                    description: Config holds fine-grained processor configuration.
+                    properties:
+                      defaultOutputExpirationSeconds:
+                        description: DefaultOutputExpirationSeconds is the TTL for
+                          job output files.
+                        format: int64
+                        type: integer
+                      enablePprof:
+                        description: EnablePprof enables the Go pprof profiling HTTP
+                          endpoints.
+                        type: boolean
+                      globalConcurrency:
+                        description: GlobalConcurrency is the maximum number of in-flight
+                          inference requests across all models.
+                        format: int32
+                        type: integer
+                      inferenceObjective:
+                        description: InferenceObjective specifies the scheduling objective
+                          (e.g. "throughput", "latency").
+                        maxLength: 253
+                        type: string
+                      logging:
+                        description: Logging configures log verbosity for the processor.
+                        properties:
+                          verbosity:
+                            description: Verbosity sets the log verbosity level (higher
+                              means more verbose).
+                            format: int32
+                            type: integer
+                        type: object
+                      numWorkers:
+                        description: NumWorkers is the number of concurrent worker
+                          goroutines processing jobs.
+                        format: int32
+                        type: integer
+                      perModelMaxConcurrency:
+                        description: PerModelMaxConcurrency is the maximum number
+                          of in-flight inference requests per model.
+                        format: int32
+                        type: integer
+                      progressTTLSeconds:
+                        description: ProgressTTLSeconds is how long in-progress job
+                          state is retained before being considered stale.
+                        format: int64
+                        type: integer
+                      recoveryMaxConcurrency:
+                        description: RecoveryMaxConcurrency is the maximum concurrency
+                          for recovering in-progress jobs after restart.
+                        format: int32
+                        type: integer
+                    type: object
+                  globalInferenceGateway:
+                    description: |-
+                      GlobalInferenceGateway is the default inference gateway used for all models
+                      unless overridden by a ModelGateways entry.
+                    properties:
+                      initialBackoff:
+                        description: InitialBackoff is the wait duration before the
+                          first retry (e.g. "500ms").
+                        maxLength: 32
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      maxBackoff:
+                        description: MaxBackoff is the maximum wait duration between
+                          retries (e.g. "30s").
+                        maxLength: 32
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      maxRetries:
+                        description: MaxRetries is the maximum number of retry attempts
+                          on transient errors.
+                        format: int32
+                        type: integer
+                      requestTimeout:
+                        description: RequestTimeout is the maximum time to wait for
+                          a single inference response (e.g. "5m").
+                        maxLength: 32
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                      tlsCACertFile:
+                        description: TLSCACertFile is the path to a custom CA certificate
+                          file for verifying the gateway's TLS certificate.
+                        maxLength: 4096
+                        type: string
+                      tlsClientCertFile:
+                        description: TLSClientCertFile is the path to the client TLS
+                          certificate file for mutual TLS.
+                        maxLength: 4096
+                        type: string
+                      tlsClientKeyFile:
+                        description: TLSClientKeyFile is the path to the client TLS
+                          private key file for mutual TLS.
+                        maxLength: 4096
+                        type: string
+                      tlsInsecureSkipVerify:
+                        description: TLSInsecureSkipVerify disables TLS certificate
+                          verification. Not recommended for production.
+                        type: boolean
+                      url:
+                        description: URL is the base URL of the inference gateway
+                          (e.g. "http://gateway.svc:8000").
+                        maxLength: 2048
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  image:
+                    description: Image is the container image for the processor (e.g.
+                      "ghcr.io/org/processor:v1.2.3").
+                    maxLength: 1024
+                    type: string
+                  modelGateways:
+                    additionalProperties:
+                      description: InferenceGatewaySpec configures a connection to
+                        an inference gateway.
                       properties:
                         initialBackoff:
-                          description: InitialBackoff is the wait duration before the first retry (e.g.
-                            "500ms").
+                          description: InitialBackoff is the wait duration before
+                            the first retry (e.g. "500ms").
                           maxLength: 32
                           pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
                         maxBackoff:
-                          description: MaxBackoff is the maximum wait duration between retries (e.g.
-                            "30s").
+                          description: MaxBackoff is the maximum wait duration between
+                            retries (e.g. "30s").
                           maxLength: 32
                           pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
                         maxRetries:
-                          description: MaxRetries is the maximum number of retry attempts on transient
-                            errors.
+                          description: MaxRetries is the maximum number of retry attempts
+                            on transient errors.
                           format: int32
                           type: integer
                         requestTimeout:
-                          description: RequestTimeout is the maximum time to wait for a single inference
-                            response (e.g. "5m").
+                          description: RequestTimeout is the maximum time to wait
+                            for a single inference response (e.g. "5m").
                           maxLength: 32
                           pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
                         tlsCACertFile:
-                          description: TLSCACertFile is the path to a custom CA certificate file for
-                            verifying the gateway's TLS certificate.
+                          description: TLSCACertFile is the path to a custom CA certificate
+                            file for verifying the gateway's TLS certificate.
                           maxLength: 4096
                           type: string
                         tlsClientCertFile:
-                          description: TLSClientCertFile is the path to the client TLS certificate file
-                            for mutual TLS.
+                          description: TLSClientCertFile is the path to the client
+                            TLS certificate file for mutual TLS.
                           maxLength: 4096
                           type: string
                         tlsClientKeyFile:
-                          description: TLSClientKeyFile is the path to the client TLS private key file for
-                            mutual TLS.
+                          description: TLSClientKeyFile is the path to the client
+                            TLS private key file for mutual TLS.
                           maxLength: 4096
                           type: string
                         tlsInsecureSkipVerify:
-                          description: TLSInsecureSkipVerify disables TLS certificate verification. Not
-                            recommended for production.
+                          description: TLSInsecureSkipVerify disables TLS certificate
+                            verification. Not recommended for production.
                           type: boolean
                         url:
-                          description: URL is the base URL of the inference gateway (e.g.
-                            "http://gateway.svc:8000").
+                          description: URL is the base URL of the inference gateway
+                            (e.g. "http://gateway.svc:8000").
                           maxLength: 2048
                           type: string
                       required:
-                        - url
+                      - url
                       type: object
-                    image:
-                      description: Image is the container image for the processor (e.g.
-                        "ghcr.io/org/processor:v1.2.3").
-                      maxLength: 1024
-                      type: string
-                    modelGateways:
-                      additionalProperties:
-                        description: InferenceGatewaySpec configures a connection to an inference
-                          gateway.
-                        properties:
-                          initialBackoff:
-                            description: InitialBackoff is the wait duration before the first retry (e.g.
-                              "500ms").
-                            maxLength: 32
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          maxBackoff:
-                            description: MaxBackoff is the maximum wait duration between retries (e.g.
-                              "30s").
-                            maxLength: 32
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          maxRetries:
-                            description: MaxRetries is the maximum number of retry attempts on transient
-                              errors.
-                            format: int32
-                            type: integer
-                          requestTimeout:
-                            description: RequestTimeout is the maximum time to wait for a single inference
-                              response (e.g. "5m").
-                            maxLength: 32
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          tlsCACertFile:
-                            description: TLSCACertFile is the path to a custom CA certificate file for
-                              verifying the gateway's TLS certificate.
-                            maxLength: 4096
-                            type: string
-                          tlsClientCertFile:
-                            description: TLSClientCertFile is the path to the client TLS certificate file
-                              for mutual TLS.
-                            maxLength: 4096
-                            type: string
-                          tlsClientKeyFile:
-                            description: TLSClientKeyFile is the path to the client TLS private key file for
-                              mutual TLS.
-                            maxLength: 4096
-                            type: string
-                          tlsInsecureSkipVerify:
-                            description: TLSInsecureSkipVerify disables TLS certificate verification. Not
-                              recommended for production.
-                            type: boolean
-                          url:
-                            description: URL is the base URL of the inference gateway (e.g.
-                              "http://gateway.svc:8000").
-                            maxLength: 2048
-                            type: string
-                        required:
-                          - url
+                    description: |-
+                      ModelGateways maps model names to per-model inference gateway configurations,
+                      overriding GlobalInferenceGateway for those models.
+                    type: object
+                  replicas:
+                    default: 1
+                    description: |-
+                      Replicas is the desired number of processor pods.
+                      Setting this to 0 suspends the processor; the Ready condition will be False.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources defines CPU and memory requests/limits
+                      for the processor container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
-                      description: |-
-                        ModelGateways maps model names to per-model inference gateway configurations,
-                        overriding GlobalInferenceGateway for those models.
-                      type: object
-                    replicas:
-                      default: 1
-                      description: |-
-                        Replicas is the desired number of processor pods.
-                        Setting this to 0 suspends the processor; the Ready condition will be False.
-                      format: int32
-                      minimum: 0
-                      type: integer
-                    resources:
-                      description: Resources defines CPU and memory requests/limits for the processor
-                        container.
-                      properties:
-                        claims:
-                          description: |-
-                            Claims lists the names of resources, defined in spec.resourceClaims,
-                            that are used by this container.
-
-                            This field depends on the
-                            DynamicResourceAllocation feature gate.
-
-                            This field is immutable. It can only be set for containers.
-                          items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                            properties:
-                              name:
-                                description: |-
-                                  Name must match the name of one entry in pod.spec.resourceClaims of
-                                  the Pod where this field is used. It makes that resource available
-                                  inside a container.
-                                type: string
-                              request:
-                                description: |-
-                                  Request is the name chosen for a request in the referenced claim.
-                                  If empty, everything from the claim is made available, otherwise
-                                  only the result of this request.
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Limits describes the maximum amount of compute resources allowed.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: |-
-                            Requests describes the minimum amount of compute resources required.
-                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                          type: object
-                      type: object
-                  required:
-                    - image
-                  type: object
-                prometheusRule:
-                  description: PrometheusRule configures a PrometheusRule resource with pre-built
-                    alerting rules.
-                  properties:
-                    enabled:
-                      description: Enabled controls whether a PrometheusRule resource is created.
-                      type: boolean
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        Labels are additional labels applied to the PrometheusRule resource,
-                        used to match Prometheus operator rule selectors.
-                      type: object
-                  type: object
-                secretRef:
-                  description: |-
-                    SecretRef references the Kubernetes Secret that holds runtime credentials
-                    (database URL, S3 keys, inference API key, etc.).
-                  properties:
-                    name:
-                      description: Name is the name of the Secret.
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              prometheusRule:
+                description: PrometheusRule configures a PrometheusRule resource with
+                  pre-built alerting rules.
+                properties:
+                  enabled:
+                    description: Enabled controls whether a PrometheusRule resource
+                      is created.
+                    type: boolean
+                  labels:
+                    additionalProperties:
                       type: string
-                  required:
-                    - name
-                  type: object
-                tls:
-                  description: TLS configures TLS termination for the API server.
-                  properties:
-                    certManager:
-                      description: |-
-                        CertManager configures automatic certificate provisioning via cert-manager.
-                        Mutually exclusive with secretName.
-                      properties:
-                        dnsNames:
-                          description: DNSNames is the list of DNS SANs to include in the issued
-                            certificate.
-                          items:
-                            maxLength: 253
-                            type: string
-                          type: array
-                        issuerKind:
-                          description: IssuerKind is the kind of the cert-manager issuer resource
-                            ("Issuer" or "ClusterIssuer").
-                          type: string
-                        issuerName:
-                          description: IssuerName is the name of the cert-manager Issuer or ClusterIssuer.
+                    description: |-
+                      Labels are additional labels applied to the PrometheusRule resource,
+                      used to match Prometheus operator rule selectors.
+                    type: object
+                type: object
+              secretRef:
+                description: |-
+                  SecretRef references the Kubernetes Secret that holds runtime credentials
+                  (database URL, S3 keys, inference API key, etc.).
+                properties:
+                  name:
+                    description: Name is the name of the Secret.
+                    type: string
+                required:
+                - name
+                type: object
+              tls:
+                description: TLS configures TLS termination for the API server.
+                properties:
+                  certManager:
+                    description: |-
+                      CertManager configures automatic certificate provisioning via cert-manager.
+                      Mutually exclusive with secretName.
+                    properties:
+                      dnsNames:
+                        description: DNSNames is the list of DNS SANs to include in
+                          the issued certificate.
+                        items:
                           maxLength: 253
                           type: string
-                      required:
-                        - issuerName
-                      type: object
-                    enabled:
-                      description: Enabled controls whether TLS termination is configured for the API
-                        server.
-                      type: boolean
-                    secretName:
-                      description: |-
-                        SecretName is the name of an existing TLS Secret (type kubernetes.io/tls)
-                        containing the certificate and key. Mutually exclusive with certManager.
-                      maxLength: 253
-                      type: string
-                  type: object
-                  x-kubernetes-validations:
-                    - message: tls.secretName or tls.certManager must be set when tls.enabled is true
-                      rule: '!self.enabled || self.secretName != ” || has(self.certManager)'
-              required:
-                - apiServer
-                - gc
-                - processor
-                - secretRef
-              type: object
-            status:
-              description: Status defines the observed state of LLMBatchGateway.
-              properties:
-                componentStatus:
-                  description: ComponentStatus reports the replica counts for each managed
-                    component.
-                  properties:
-                    apiServer:
-                      description: APIServer reports the replica status of the API server Deployment.
-                      properties:
-                        readyReplicas:
-                          description: ReadyReplicas is the number of pods that have passed their
-                            readiness checks.
-                          format: int32
-                          type: integer
-                        replicas:
-                          description: Replicas is the total number of non-terminated pods.
-                          format: int32
-                          type: integer
-                      required:
-                        - readyReplicas
-                        - replicas
-                      type: object
-                    gc:
-                      description: GC reports the replica status of the garbage-collector Deployment.
-                      properties:
-                        readyReplicas:
-                          description: ReadyReplicas is the number of pods that have passed their
-                            readiness checks.
-                          format: int32
-                          type: integer
-                        replicas:
-                          description: Replicas is the total number of non-terminated pods.
-                          format: int32
-                          type: integer
-                      required:
-                        - readyReplicas
-                        - replicas
-                      type: object
-                    processor:
-                      description: Processor reports the replica status of the processor Deployment.
-                      properties:
-                        readyReplicas:
-                          description: ReadyReplicas is the number of pods that have passed their
-                            readiness checks.
-                          format: int32
-                          type: integer
-                        replicas:
-                          description: Replicas is the total number of non-terminated pods.
-                          format: int32
-                          type: integer
-                      required:
-                        - readyReplicas
-                        - replicas
-                      type: object
-                  type: object
-                conditions:
-                  description: |-
-                    Conditions represent the latest available observations of the LLMBatchGateway's state.
-                    Known condition types: Ready, APIServerAvailable, ProcessorAvailable, GCAvailable.
-                  items:
-                    description: Condition contains details for one aspect of the current state of
-                      this API Resource.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          message is a human readable message indicating details about the transition.
-                          This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: |-
-                          observedGeneration represents the .metadata.generation that the condition was set based upon.
-                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                          with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: |-
-                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                          Producers of specific condition types may define expected values and meanings for this field,
-                          and whether the values are considered a guaranteed API.
-                          The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
+                        type: array
+                      issuerKind:
+                        default: ClusterIssuer
+                        description: IssuerKind is the kind of the cert-manager issuer
+                          resource.
                         enum:
-                          - "True"
-                          - "False"
-                          - Unknown
+                        - Issuer
+                        - ClusterIssuer
                         type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      issuerName:
+                        description: IssuerName is the name of the cert-manager Issuer
+                          or ClusterIssuer.
+                        maxLength: 253
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - issuerName
                     type: object
-                  type: array
-                observedGeneration:
-                  description: ObservedGeneration is the .metadata.generation that was last
-                    processed by the controller.
-                  format: int64
-                  type: integer
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    x-kubernetes-validations:
+                    - message: certManager.issuerName must be set
+                      rule: self.issuerName != ''
+                  enabled:
+                    description: Enabled controls whether TLS termination is configured
+                      for the API server.
+                    type: boolean
+                  secretName:
+                    description: |-
+                      SecretName is the name of an existing TLS Secret (type kubernetes.io/tls)
+                      containing the certificate and key. Mutually exclusive with certManager.
+                    maxLength: 253
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: tls.secretName or tls.certManager must be set when tls.enabled
+                    is true
+                  rule: '!self.enabled || self.secretName != '''' || has(self.certManager)'
+                - message: tls.secretName and tls.certManager are mutually exclusive
+                  rule: '!(self.secretName != '''' && has(self.certManager))'
+            required:
+            - apiServer
+            - gc
+            - processor
+            - secretRef
+            type: object
+          status:
+            description: Status defines the observed state of LLMBatchGateway.
+            properties:
+              componentStatus:
+                description: ComponentStatus reports the replica counts for each managed
+                  component.
+                properties:
+                  apiServer:
+                    description: APIServer reports the replica status of the API server
+                      Deployment.
+                    properties:
+                      readyReplicas:
+                        description: ReadyReplicas is the number of pods that have
+                          passed their readiness checks.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Replicas is the total number of non-terminated
+                          pods.
+                        format: int32
+                        type: integer
+                    required:
+                    - readyReplicas
+                    - replicas
+                    type: object
+                  gc:
+                    description: GC reports the replica status of the garbage-collector
+                      Deployment.
+                    properties:
+                      readyReplicas:
+                        description: ReadyReplicas is the number of pods that have
+                          passed their readiness checks.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Replicas is the total number of non-terminated
+                          pods.
+                        format: int32
+                        type: integer
+                    required:
+                    - readyReplicas
+                    - replicas
+                    type: object
+                  processor:
+                    description: Processor reports the replica status of the processor
+                      Deployment.
+                    properties:
+                      readyReplicas:
+                        description: ReadyReplicas is the number of pods that have
+                          passed their readiness checks.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Replicas is the total number of non-terminated
+                          pods.
+                        format: int32
+                        type: integer
+                    required:
+                    - readyReplicas
+                    - replicas
+                    type: object
+                type: object
+              conditions:
+                description: |-
+                  Conditions represent the latest available observations of the LLMBatchGateway's state.
+                  Known condition types: Ready, APIServerAvailable, ProcessorAvailable, GCAvailable.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the .metadata.generation that was
+                  last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -243,10 +243,12 @@ spec:
                       basePath:
                         description: BasePath is the root directory inside the PVC
                           where files are stored.
+                        maxLength: 4096
                         type: string
-                      pvcName:
-                        description: PVCName is the name of the PersistentVolumeClaim
+                      claimName:
+                        description: ClaimName is the name of the PersistentVolumeClaim
                           to mount.
+                        maxLength: 253
                         type: string
                     type: object
                   retry:

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -237,8 +237,8 @@ spec:
                   input/output files. If omitted, S3 defaults are used.
                 properties:
                   fs:
-                    description: FS configures PVC-backed filesystem storage. Required
-                      when type is 'fs'.
+                    description: FS configures PVC-backed filesystem storage. Mutually
+                      exclusive with s3.
                     properties:
                       basePath:
                         description: BasePath is the root directory inside the PVC
@@ -272,8 +272,8 @@ spec:
                         type: integer
                     type: object
                   s3:
-                    description: S3 configures S3-compatible object storage. Required
-                      when type is 's3'.
+                    description: S3 configures S3-compatible object storage. Mutually
+                      exclusive with fs.
                     properties:
                       accessKeyId:
                         description: |-
@@ -304,21 +304,11 @@ spec:
                           by some S3-compatible stores).
                         type: boolean
                     type: object
-                  type:
-                    default: s3
-                    description: |-
-                      Type selects the storage backend. Use 's3' for any S3-compatible object store,
-                      or 'fs' for a PersistentVolumeClaim-backed filesystem.
-                    enum:
-                    - fs
-                    - s3
-                    type: string
                 type: object
                 x-kubernetes-validations:
-                - message: fileStorage.fs must be set when type is 'fs'
-                  rule: self.type != 'fs' || has(self.fs)
-                - message: fileStorage.fs must not be set when type is 's3'
-                  rule: self.type != 's3' || !has(self.fs)
+                - message: exactly one of fileStorage.s3 or fileStorage.fs must be
+                    set
+                  rule: has(self.s3) != has(self.fs)
               gc:
                 description: GC configures the garbage-collector component that expires
                   old jobs and files.

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -12,576 +12,863 @@ spec:
     listKind: LLMBatchGatewayList
     plural: llmbatchgateways
     shortNames:
-    - lbg
+      - lbg
     singular: llmbatchgateway
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              apiServer:
-                properties:
-                  config:
-                    properties:
-                      batchAPI:
-                        properties:
-                          eventTTLSeconds:
-                            format: int32
-                            type: integer
-                          passThroughHeaders:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      enablePprof:
-                        type: boolean
-                      fileAPI:
-                        properties:
-                          defaultExpirationSeconds:
-                            format: int64
-                            type: integer
-                          maxLineCount:
-                            format: int64
-                            type: integer
-                          maxSizeBytes:
-                            format: int64
-                            type: integer
-                        type: object
-                      idleTimeoutSeconds:
-                        format: int32
-                        type: integer
-                      logging:
-                        properties:
-                          verbosity:
-                            format: int32
-                            type: integer
-                        type: object
-                      observabilityPort:
-                        type: string
-                      port:
-                        type: string
-                      readTimeoutSeconds:
-                        format: int32
-                        type: integer
-                      writeTimeoutSeconds:
-                        format: int32
-                        type: integer
-                    type: object
-                  image:
-                    type: string
-                  replicas:
-                    default: 1
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This field depends on the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
-                        items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                          properties:
-                            name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
-                              type: string
-                            request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                    type: object
-                required:
-                - image
-                type: object
-              dbBackend:
-                default: postgresql
-                enum:
-                - redis
-                - postgresql
-                - valkey
-                type: string
-              fileStorage:
-                properties:
-                  fs:
-                    properties:
-                      basePath:
-                        type: string
-                      pvcName:
-                        type: string
-                    type: object
-                  retry:
-                    properties:
-                      initialBackoff:
-                        default: 1s
-                        type: string
-                      maxBackoff:
-                        default: 10s
-                        type: string
-                      maxRetries:
-                        default: 3
-                        format: int32
-                        type: integer
-                    type: object
-                  s3:
-                    properties:
-                      accessKeyId:
-                        type: string
-                      autoCreateBucket:
-                        type: boolean
-                      endpoint:
-                        type: string
-                      prefix:
-                        type: string
-                      region:
-                        type: string
-                      usePathStyle:
-                        type: boolean
-                    type: object
-                  type:
-                    default: s3
-                    enum:
-                    - fs
-                    - s3
-                    type: string
-                type: object
-              gc:
-                properties:
-                  config:
-                    properties:
-                      dryRun:
-                        type: boolean
-                      logging:
-                        properties:
-                          verbosity:
-                            format: int32
-                            type: integer
-                        type: object
-                      maxConcurrency:
-                        format: int32
-                        type: integer
-                    type: object
-                  image:
-                    type: string
-                  interval:
-                    default: 30m
-                    type: string
-                required:
-                - image
-                type: object
-              grafana:
-                properties:
-                  enabled:
-                    type: boolean
-                type: object
-              httpRoute:
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  enabled:
-                    type: boolean
-                  parentRefs:
-                    items:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.componentStatus.apiServer.readyReplicas
+          name: API-Ready
+          type: integer
+        - jsonPath: .status.componentStatus.processor.readyReplicas
+          name: Proc-Ready
+          type: integer
+        - jsonPath: .status.componentStatus.gc.readyReplicas
+          name: GC-Ready
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            LLMBatchGateway is the Schema for the llmbatchgateways API.
+            It represents a fully-managed deployment of the LLM-D batch gateway,
+            consisting of an API server, a request processor and a garbage-collector.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of LLMBatchGateway.
+              properties:
+                apiServer:
+                  description: APIServer configures the HTTP API server component.
+                  properties:
+                    config:
+                      description: Config holds fine-grained API server configuration.
                       properties:
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                        sectionName:
-                          type: string
-                      required:
-                      - name
+                        batchAPI:
+                          description: BatchAPI configures the batch job submission endpoint behaviour.
+                          properties:
+                            eventTTLSeconds:
+                              description: EventTTLSeconds is how long job events are retained before expiry.
+                              format: int32
+                              type: integer
+                            passThroughHeaders:
+                              description: PassThroughHeaders is a list of HTTP request headers forwarded to
+                                the inference backend.
+                              items:
+                                maxLength: 256
+                                type: string
+                              type: array
+                          type: object
+                        enablePprof:
+                          description: EnablePprof enables the Go pprof profiling HTTP endpoints.
+                          type: boolean
+                        fileAPI:
+                          description: FileAPI configures the file upload/download endpoint behaviour.
+                          properties:
+                            defaultExpirationSeconds:
+                              description: DefaultExpirationSeconds is the default TTL for uploaded files.
+                              format: int64
+                              type: integer
+                            maxLineCount:
+                              description: MaxLineCount is the maximum number of lines allowed in a JSONL
+                                batch input file.
+                              format: int64
+                              type: integer
+                            maxSizeBytes:
+                              description: MaxSizeBytes is the maximum allowed size of a single uploaded file.
+                              format: int64
+                              type: integer
+                          type: object
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum amount of time to wait for the
+                            next request.
+                          format: int32
+                          type: integer
+                        logging:
+                          description: Logging configures log verbosity for the API server.
+                          properties:
+                            verbosity:
+                              description: Verbosity sets the log verbosity level (higher means more verbose).
+                              format: int32
+                              type: integer
+                          type: object
+                        observabilityPort:
+                          description: ObservabilityPort is the TCP port that exposes metrics and health
+                            endpoints.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        port:
+                          description: Port is the TCP port the API server listens on.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        readTimeoutSeconds:
+                          description: ReadTimeoutSeconds is the maximum duration for reading an entire
+                            HTTP request.
+                          format: int32
+                          type: integer
+                        writeTimeoutSeconds:
+                          description: WriteTimeoutSeconds is the maximum duration before timing out
+                            writes of the response.
+                          format: int32
+                          type: integer
                       type: object
-                    type: array
-                type: object
-              monitoring:
-                properties:
-                  enabled:
-                    type: boolean
-                type: object
-              otel:
-                properties:
-                  endpoint:
-                    type: string
-                  insecure:
-                    type: boolean
-                  postgresqlTracing:
-                    type: boolean
-                  redisTracing:
-                    type: boolean
-                  sampler:
-                    type: string
-                  samplerArg:
-                    type: string
-                type: object
-              processor:
-                properties:
-                  config:
-                    properties:
-                      defaultOutputExpirationSeconds:
-                        format: int64
-                        type: integer
-                      enablePprof:
-                        type: boolean
-                      globalConcurrency:
-                        format: int32
-                        type: integer
-                      inferenceObjective:
-                        type: string
-                      logging:
-                        properties:
-                          verbosity:
-                            format: int32
-                            type: integer
-                        type: object
-                      numWorkers:
-                        format: int32
-                        type: integer
-                      perModelMaxConcurrency:
-                        format: int32
-                        type: integer
-                      progressTTLSeconds:
-                        format: int64
-                        type: integer
-                      recoveryMaxConcurrency:
-                        format: int32
-                        type: integer
-                    type: object
-                  globalInferenceGateway:
-                    properties:
-                      initialBackoff:
-                        type: string
-                      maxBackoff:
-                        type: string
-                      maxRetries:
-                        format: int32
-                        type: integer
-                      requestTimeout:
-                        type: string
-                      tlsCaCertFile:
-                        type: string
-                      tlsClientCertFile:
-                        type: string
-                      tlsClientKeyFile:
-                        type: string
-                      tlsInsecureSkipVerify:
-                        type: boolean
-                      url:
-                        type: string
-                    required:
-                    - url
-                    type: object
-                  image:
-                    type: string
-                  modelGateways:
-                    additionalProperties:
+                    image:
+                      description: Image is the container image for the API server (e.g.
+                        "ghcr.io/org/apiserver:v1.2.3").
+                      maxLength: 1024
+                      type: string
+                    replicas:
+                      default: 1
+                      description: |-
+                        Replicas is the desired number of API server pods.
+                        Setting this to 0 suspends the API server; the Ready condition will be False.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    resources:
+                      description: Resources defines CPU and memory requests/limits for the API server
+                        container.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                    - image
+                  type: object
+                dbBackend:
+                  default: postgresql
+                  description: DBBackend selects the database backend used for job state storage.
+                  enum:
+                    - redis
+                    - postgresql
+                    - valkey
+                  type: string
+                fileStorage:
+                  description: |-
+                    FileStorage configures the file storage backend used to persist batch
+                    input/output files. If omitted, S3 defaults are used.
+                  properties:
+                    fs:
+                      description: FS configures PVC-backed filesystem storage. Required when type is
+                        'fs'.
+                      properties:
+                        basePath:
+                          description: BasePath is the root directory inside the PVC where files are
+                            stored.
+                          type: string
+                        pvcName:
+                          description: PVCName is the name of the PersistentVolumeClaim to mount.
+                          type: string
+                      type: object
+                    retry:
+                      description: Retry configures retry behaviour for transient file storage errors.
                       properties:
                         initialBackoff:
+                          default: 1s
+                          description: InitialBackoff is the wait duration before the first retry (e.g.
+                            "1s").
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
                         maxBackoff:
+                          default: 10s
+                          description: MaxBackoff is the maximum wait duration between retries (e.g.
+                            "10s").
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
                         maxRetries:
+                          default: 3
+                          description: MaxRetries is the maximum number of retry attempts.
+                          format: int32
+                          type: integer
+                      type: object
+                    s3:
+                      description: S3 configures S3-compatible object storage. Required when type is
+                        's3'.
+                      properties:
+                        accessKeyId:
+                          description: |-
+                            AccessKeyID is the S3 access key ID (non-sensitive). The corresponding
+                            secret access key must be provided via spec.secretRef.
+                          maxLength: 1024
+                          type: string
+                        autoCreateBucket:
+                          description: AutoCreateBucket causes the operator to create the bucket if it
+                            does not exist.
+                          type: boolean
+                        endpoint:
+                          description: Endpoint overrides the S3 endpoint URL for non-AWS providers (e.g.
+                            MinIO).
+                          maxLength: 2048
+                          type: string
+                        prefix:
+                          description: Prefix is an optional key prefix applied to all objects written to
+                            the bucket.
+                          maxLength: 1024
+                          type: string
+                        region:
+                          description: Region is the AWS region (e.g. "us-east-1").
+                          maxLength: 253
+                          type: string
+                        usePathStyle:
+                          description: UsePathStyle forces path-style addressing (required by some
+                            S3-compatible stores).
+                          type: boolean
+                      type: object
+                    type:
+                      default: s3
+                      description: |-
+                        Type selects the storage backend. Use 's3' for any S3-compatible object store,
+                        or 'fs' for a PersistentVolumeClaim-backed filesystem.
+                      enum:
+                        - fs
+                        - s3
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: fileStorage.fs must be set when type is 'fs'
+                      rule: self.type != 'fs' || has(self.fs)
+                    - message: fileStorage.fs must not be set when type is 's3'
+                      rule: self.type != 's3' || !has(self.fs)
+                gc:
+                  description: GC configures the garbage-collector component that expires old jobs
+                    and files.
+                  properties:
+                    config:
+                      description: Config holds fine-grained GC configuration.
+                      properties:
+                        dryRun:
+                          description: DryRun causes the GC to log what it would delete without actually
+                            deleting anything.
+                          type: boolean
+                        logging:
+                          description: Logging configures log verbosity for the GC.
+                          properties:
+                            verbosity:
+                              description: Verbosity sets the log verbosity level (higher means more verbose).
+                              format: int32
+                              type: integer
+                          type: object
+                        maxConcurrency:
+                          description: MaxConcurrency is the maximum number of deletion operations
+                            performed in parallel.
+                          format: int32
+                          type: integer
+                      type: object
+                    image:
+                      description: Image is the container image for the GC (e.g.
+                        "ghcr.io/org/batch-gc:v1.2.3").
+                      maxLength: 1024
+                      type: string
+                    interval:
+                      default: 30m
+                      description: Interval is how often the GC runs (e.g. "30m").
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                      type: string
+                  required:
+                    - image
+                  type: object
+                grafana:
+                  description: Grafana enables the bundled Grafana dashboard ConfigMap.
+                  properties:
+                    enabled:
+                      description: Enabled controls whether a Grafana dashboard ConfigMap is created.
+                      type: boolean
+                  type: object
+                httpRoute:
+                  description: HTTPRoute configures a Gateway API HTTPRoute resource to expose the
+                    API server.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations are extra annotations applied to the HTTPRoute
+                        resource.
+                      type: object
+                    enabled:
+                      description: Enabled controls whether an HTTPRoute resource is created.
+                      type: boolean
+                    parentRefs:
+                      description: ParentRefs is the list of Gateways this HTTPRoute should attach to.
+                      items:
+                        description: ParentReference identifies a Gateway to which an HTTPRoute should
+                          attach.
+                        properties:
+                          name:
+                            description: Name is the name of the Gateway resource.
+                            maxLength: 253
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Gateway resource. Defaults to the
+                              HTTPRoute's namespace.
+                            maxLength: 63
+                            type: string
+                          sectionName:
+                            description: SectionName is the name of a specific listener on the Gateway to
+                              attach to.
+                            maxLength: 253
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                  type: object
+                monitoring:
+                  description: Monitoring enables Prometheus ServiceMonitor and PodMonitor
+                    resources.
+                  properties:
+                    enabled:
+                      description: Enabled controls whether a ServiceMonitor and PodMonitor are
+                        created for each component.
+                      type: boolean
+                  type: object
+                otel:
+                  description: OTEL configures OpenTelemetry tracing for all components.
+                  properties:
+                    endpoint:
+                      description: Endpoint is the OTLP gRPC or HTTP endpoint (e.g.
+                        "http://collector:4317").
+                      maxLength: 2048
+                      type: string
+                    insecure:
+                      description: Insecure disables TLS for the OTLP connection.
+                      type: boolean
+                    postgresqlTracing:
+                      description: PostgresqlTracing enables tracing of PostgreSQL operations.
+                      type: boolean
+                    redisTracing:
+                      description: RedisTracing enables tracing of Redis operations.
+                      type: boolean
+                    sampler:
+                      description: Sampler is the OTEL sampler type (e.g. "parentbased_traceidratio").
+                      maxLength: 253
+                      type: string
+                    samplerArg:
+                      description: SamplerArg is the argument passed to the sampler (e.g. "0.1" for
+                        10% sampling).
+                      maxLength: 253
+                      type: string
+                  type: object
+                processor:
+                  description: Processor configures the request-processing worker component.
+                  properties:
+                    config:
+                      description: Config holds fine-grained processor configuration.
+                      properties:
+                        defaultOutputExpirationSeconds:
+                          description: DefaultOutputExpirationSeconds is the TTL for job output files.
+                          format: int64
+                          type: integer
+                        enablePprof:
+                          description: EnablePprof enables the Go pprof profiling HTTP endpoints.
+                          type: boolean
+                        globalConcurrency:
+                          description: GlobalConcurrency is the maximum number of in-flight inference
+                            requests across all models.
+                          format: int32
+                          type: integer
+                        inferenceObjective:
+                          description: InferenceObjective specifies the scheduling objective (e.g.
+                            "throughput", "latency").
+                          maxLength: 253
+                          type: string
+                        logging:
+                          description: Logging configures log verbosity for the processor.
+                          properties:
+                            verbosity:
+                              description: Verbosity sets the log verbosity level (higher means more verbose).
+                              format: int32
+                              type: integer
+                          type: object
+                        numWorkers:
+                          description: NumWorkers is the number of concurrent worker goroutines processing
+                            jobs.
+                          format: int32
+                          type: integer
+                        perModelMaxConcurrency:
+                          description: PerModelMaxConcurrency is the maximum number of in-flight inference
+                            requests per model.
+                          format: int32
+                          type: integer
+                        progressTTLSeconds:
+                          description: ProgressTTLSeconds is how long in-progress job state is retained
+                            before being considered stale.
+                          format: int64
+                          type: integer
+                        recoveryMaxConcurrency:
+                          description: RecoveryMaxConcurrency is the maximum concurrency for recovering
+                            in-progress jobs after restart.
+                          format: int32
+                          type: integer
+                      type: object
+                    globalInferenceGateway:
+                      description: |-
+                        GlobalInferenceGateway is the default inference gateway used for all models
+                        unless overridden by a ModelGateways entry.
+                      properties:
+                        initialBackoff:
+                          description: InitialBackoff is the wait duration before the first retry (e.g.
+                            "500ms").
+                          maxLength: 32
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          type: string
+                        maxBackoff:
+                          description: MaxBackoff is the maximum wait duration between retries (e.g.
+                            "30s").
+                          maxLength: 32
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          type: string
+                        maxRetries:
+                          description: MaxRetries is the maximum number of retry attempts on transient
+                            errors.
                           format: int32
                           type: integer
                         requestTimeout:
+                          description: RequestTimeout is the maximum time to wait for a single inference
+                            response (e.g. "5m").
+                          maxLength: 32
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
-                        tlsCaCertFile:
+                        tlsCACertFile:
+                          description: TLSCACertFile is the path to a custom CA certificate file for
+                            verifying the gateway's TLS certificate.
+                          maxLength: 4096
                           type: string
                         tlsClientCertFile:
+                          description: TLSClientCertFile is the path to the client TLS certificate file
+                            for mutual TLS.
+                          maxLength: 4096
                           type: string
                         tlsClientKeyFile:
+                          description: TLSClientKeyFile is the path to the client TLS private key file for
+                            mutual TLS.
+                          maxLength: 4096
                           type: string
                         tlsInsecureSkipVerify:
+                          description: TLSInsecureSkipVerify disables TLS certificate verification. Not
+                            recommended for production.
                           type: boolean
                         url:
+                          description: URL is the base URL of the inference gateway (e.g.
+                            "http://gateway.svc:8000").
+                          maxLength: 2048
                           type: string
                       required:
-                      - url
+                        - url
                       type: object
-                    type: object
-                  replicas:
-                    default: 1
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-                          This field depends on the
-                          DynamicResourceAllocation feature gate.
-
-                          This field is immutable. It can only be set for containers.
-                        items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                          properties:
-                            name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
-                              type: string
-                            request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    image:
+                      description: Image is the container image for the processor (e.g.
+                        "ghcr.io/org/processor:v1.2.3").
+                      maxLength: 1024
+                      type: string
+                    modelGateways:
+                      additionalProperties:
+                        description: InferenceGatewaySpec configures a connection to an inference
+                          gateway.
+                        properties:
+                          initialBackoff:
+                            description: InitialBackoff is the wait duration before the first retry (e.g.
+                              "500ms").
+                            maxLength: 32
+                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                            type: string
+                          maxBackoff:
+                            description: MaxBackoff is the maximum wait duration between retries (e.g.
+                              "30s").
+                            maxLength: 32
+                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                            type: string
+                          maxRetries:
+                            description: MaxRetries is the maximum number of retry attempts on transient
+                              errors.
+                            format: int32
+                            type: integer
+                          requestTimeout:
+                            description: RequestTimeout is the maximum time to wait for a single inference
+                              response (e.g. "5m").
+                            maxLength: 32
+                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                            type: string
+                          tlsCACertFile:
+                            description: TLSCACertFile is the path to a custom CA certificate file for
+                              verifying the gateway's TLS certificate.
+                            maxLength: 4096
+                            type: string
+                          tlsClientCertFile:
+                            description: TLSClientCertFile is the path to the client TLS certificate file
+                              for mutual TLS.
+                            maxLength: 4096
+                            type: string
+                          tlsClientKeyFile:
+                            description: TLSClientKeyFile is the path to the client TLS private key file for
+                              mutual TLS.
+                            maxLength: 4096
+                            type: string
+                          tlsInsecureSkipVerify:
+                            description: TLSInsecureSkipVerify disables TLS certificate verification. Not
+                              recommended for production.
+                            type: boolean
+                          url:
+                            description: URL is the base URL of the inference gateway (e.g.
+                              "http://gateway.svc:8000").
+                            maxLength: 2048
+                            type: string
+                        required:
+                          - url
                         type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                        type: object
-                    type: object
-                required:
-                - image
-                type: object
-              prometheusRule:
-                properties:
-                  enabled:
-                    type: boolean
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-              secretRef:
-                properties:
-                  name:
-                    type: string
-                required:
-                - name
-                type: object
-              tls:
-                properties:
-                  certManager:
-                    properties:
-                      dnsNames:
-                        items:
-                          type: string
-                        type: array
-                      issuerKind:
-                        type: string
-                      issuerName:
-                        type: string
-                    type: object
-                  enabled:
-                    type: boolean
-                  secretName:
-                    type: string
-                type: object
-            required:
-            - apiServer
-            - gc
-            - processor
-            - secretRef
-            type: object
-          status:
-            properties:
-              componentStatus:
-                properties:
-                  apiServer:
-                    properties:
-                      readyReplicas:
-                        format: int32
-                        type: integer
-                      replicas:
-                        format: int32
-                        type: integer
-                    required:
-                    - readyReplicas
-                    - replicas
-                    type: object
-                  gc:
-                    properties:
-                      readyReplicas:
-                        format: int32
-                        type: integer
-                      replicas:
-                        format: int32
-                        type: integer
-                    required:
-                    - readyReplicas
-                    - replicas
-                    type: object
-                  processor:
-                    properties:
-                      readyReplicas:
-                        format: int32
-                        type: integer
-                      replicas:
-                        format: int32
-                        type: integer
-                    required:
-                    - readyReplicas
-                    - replicas
-                    type: object
-                type: object
-              conditions:
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
+                        ModelGateways maps model names to per-model inference gateway configurations,
+                        overriding GlobalInferenceGateway for those models.
+                      type: object
+                    replicas:
+                      default: 1
                       description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
+                        Replicas is the desired number of processor pods.
+                        Setting this to 0 suspends the processor; the Ready condition will be False.
+                      format: int32
                       minimum: 0
                       type: integer
-                    reason:
+                    resources:
+                      description: Resources defines CPU and memory requests/limits for the processor
+                        container.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                    - image
+                  type: object
+                prometheusRule:
+                  description: PrometheusRule configures a PrometheusRule resource with pre-built
+                    alerting rules.
+                  properties:
+                    enabled:
+                      description: Enabled controls whether a PrometheusRule resource is created.
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
                       description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        Labels are additional labels applied to the PrometheusRule resource,
+                        used to match Prometheus operator rule selectors.
+                      type: object
+                  type: object
+                secretRef:
+                  description: |-
+                    SecretRef references the Kubernetes Secret that holds runtime credentials
+                    (database URL, S3 keys, inference API key, etc.).
+                  properties:
+                    name:
+                      description: Name is the name of the Secret.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              observedGeneration:
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                tls:
+                  description: TLS configures TLS termination for the API server.
+                  properties:
+                    certManager:
+                      description: |-
+                        CertManager configures automatic certificate provisioning via cert-manager.
+                        Mutually exclusive with secretName.
+                      properties:
+                        dnsNames:
+                          description: DNSNames is the list of DNS SANs to include in the issued
+                            certificate.
+                          items:
+                            maxLength: 253
+                            type: string
+                          type: array
+                        issuerKind:
+                          description: IssuerKind is the kind of the cert-manager issuer resource
+                            ("Issuer" or "ClusterIssuer").
+                          type: string
+                        issuerName:
+                          description: IssuerName is the name of the cert-manager Issuer or ClusterIssuer.
+                          maxLength: 253
+                          type: string
+                      required:
+                        - issuerName
+                      type: object
+                    enabled:
+                      description: Enabled controls whether TLS termination is configured for the API
+                        server.
+                      type: boolean
+                    secretName:
+                      description: |-
+                        SecretName is the name of an existing TLS Secret (type kubernetes.io/tls)
+                        containing the certificate and key. Mutually exclusive with certManager.
+                      maxLength: 253
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: tls.secretName or tls.certManager must be set when tls.enabled is true
+                      rule: '!self.enabled || self.secretName != ” || has(self.certManager)'
+              required:
+                - apiServer
+                - gc
+                - processor
+                - secretRef
+              type: object
+            status:
+              description: Status defines the observed state of LLMBatchGateway.
+              properties:
+                componentStatus:
+                  description: ComponentStatus reports the replica counts for each managed
+                    component.
+                  properties:
+                    apiServer:
+                      description: APIServer reports the replica status of the API server Deployment.
+                      properties:
+                        readyReplicas:
+                          description: ReadyReplicas is the number of pods that have passed their
+                            readiness checks.
+                          format: int32
+                          type: integer
+                        replicas:
+                          description: Replicas is the total number of non-terminated pods.
+                          format: int32
+                          type: integer
+                      required:
+                        - readyReplicas
+                        - replicas
+                      type: object
+                    gc:
+                      description: GC reports the replica status of the garbage-collector Deployment.
+                      properties:
+                        readyReplicas:
+                          description: ReadyReplicas is the number of pods that have passed their
+                            readiness checks.
+                          format: int32
+                          type: integer
+                        replicas:
+                          description: Replicas is the total number of non-terminated pods.
+                          format: int32
+                          type: integer
+                      required:
+                        - readyReplicas
+                        - replicas
+                      type: object
+                    processor:
+                      description: Processor reports the replica status of the processor Deployment.
+                      properties:
+                        readyReplicas:
+                          description: ReadyReplicas is the number of pods that have passed their
+                            readiness checks.
+                          format: int32
+                          type: integer
+                        replicas:
+                          description: Replicas is the total number of non-terminated pods.
+                          format: int32
+                          type: integer
+                      required:
+                        - readyReplicas
+                        - replicas
+                      type: object
+                  type: object
+                conditions:
+                  description: |-
+                    Conditions represent the latest available observations of the LLMBatchGateway's state.
+                    Known condition types: Ready, APIServerAvailable, ProcessorAvailable, GCAvailable.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: ObservedGeneration is the .metadata.generation that was last
+                    processed by the controller.
+                  format: int64
+                  type: integer
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/samples/batch_v1alpha1_llmbatchgateway.yaml
+++ b/config/samples/batch_v1alpha1_llmbatchgateway.yaml
@@ -7,7 +7,6 @@ spec:
     name: batch-gateway-secrets
   dbBackend: postgresql
   fileStorage:
-    type: s3
     s3:
       region: us-east-1
       endpoint: https://s3.example.com

--- a/config/samples/dev.yaml
+++ b/config/samples/dev.yaml
@@ -7,7 +7,6 @@ spec:
     name: batch-gateway-secrets
   dbBackend: postgresql
   fileStorage:
-    type: s3
     s3:
       region: us-east-1
       endpoint: http://minio.default.svc.cluster.local:9000

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -110,7 +110,7 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway) (map[string]interface{}
 			fs := gw.Spec.FileStorage.FS
 			fsVals := map[string]interface{}{}
 			setIfNotEmpty(fsVals, "basePath", fs.BasePath)
-			setIfNotEmpty(fsVals, "pvcName", fs.PVCName)
+			setIfNotEmpty(fsVals, "pvcName", fs.ClaimName)
 			fc["fs"] = fsVals
 		}
 		if gw.Spec.FileStorage.Retry != nil {

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -90,10 +90,9 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway) (map[string]interface{}
 	}
 
 	if gw.Spec.FileStorage != nil {
-		fc := map[string]interface{}{
-			"type": gw.Spec.FileStorage.Type,
-		}
+		fc := map[string]interface{}{}
 		if gw.Spec.FileStorage.S3 != nil {
+			fc["type"] = "s3"
 			s3 := gw.Spec.FileStorage.S3
 			s3Vals := map[string]interface{}{}
 			setIfNotEmpty(s3Vals, "region", s3.Region)
@@ -107,6 +106,7 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway) (map[string]interface{}
 			fc["s3"] = s3Vals
 		}
 		if gw.Spec.FileStorage.FS != nil {
+			fc["type"] = "fs"
 			fs := gw.Spec.FileStorage.FS
 			fsVals := map[string]interface{}{}
 			setIfNotEmpty(fsVals, "basePath", fs.BasePath)

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -357,8 +357,12 @@ func inferenceGatewayToMap(gw *batchv1alpha1.InferenceGatewaySpec) map[string]in
 
 func apiServerConfigToMap(cfg *batchv1alpha1.APIServerConfigSpec) map[string]interface{} {
 	m := map[string]interface{}{}
-	setIfNotEmpty(m, "port", cfg.Port)
-	setIfNotEmpty(m, "observabilityPort", cfg.ObservabilityPort)
+	if cfg.Port != 0 {
+		m["port"] = int64(cfg.Port)
+	}
+	if cfg.ObservabilityPort != 0 {
+		m["observabilityPort"] = int64(cfg.ObservabilityPort)
+	}
 	if cfg.ReadTimeoutSeconds != 0 {
 		m["readTimeoutSeconds"] = int64(cfg.ReadTimeoutSeconds)
 	}

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -93,7 +93,6 @@ func TestSpecToHelmValues(t *testing.T) {
 			},
 			DBBackend: "postgresql",
 			FileStorage: &batchv1alpha1.FileStorageSpec{
-				Type: "s3",
 				S3: &batchv1alpha1.S3StorageSpec{
 					Region:   "us-east-1",
 					Endpoint: "https://s3.example.com",
@@ -463,7 +462,6 @@ func minimalGateway() *batchv1alpha1.LLMBatchGateway {
 			},
 			DBBackend: "postgresql",
 			FileStorage: &batchv1alpha1.FileStorageSpec{
-				Type: "s3",
 				S3: &batchv1alpha1.S3StorageSpec{
 					Region:   "us-east-1",
 					Endpoint: "https://s3.example.com",

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -26,6 +26,7 @@ const (
 	ConditionReady              = "Ready"
 	ConditionAPIServerAvailable = "APIServerAvailable"
 	ConditionProcessorAvailable = "ProcessorAvailable"
+	ConditionGCAvailable        = "GCAvailable"
 
 	fieldOwner = "llmbatchgateway-controller"
 )
@@ -244,6 +245,7 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 		Type:               ConditionAPIServerAvailable,
 		Status:             conditionStatus(apiAvailable),
 		Reason:             conditionReason(apiAvailable, "Available", "Unavailable"),
+		Message:            conditionMessage(apiAvailable, "API server has at least one ready replica", "API server has no ready replicas"),
 		ObservedGeneration: gw.Generation,
 	})
 
@@ -252,14 +254,25 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 		Type:               ConditionProcessorAvailable,
 		Status:             conditionStatus(procAvailable),
 		Reason:             conditionReason(procAvailable, "Available", "Unavailable"),
+		Message:            conditionMessage(procAvailable, "Processor has at least one ready replica", "Processor has no ready replicas"),
 		ObservedGeneration: gw.Generation,
 	})
 
-	ready := apiAvailable && procAvailable
+	gcAvailable := componentStatus.GC != nil && componentStatus.GC.ReadyReplicas >= 1
+	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
+		Type:               ConditionGCAvailable,
+		Status:             conditionStatus(gcAvailable),
+		Reason:             conditionReason(gcAvailable, "Available", "Unavailable"),
+		Message:            conditionMessage(gcAvailable, "GC has at least one ready replica", "GC has no ready replicas"),
+		ObservedGeneration: gw.Generation,
+	})
+
+	ready := apiAvailable && procAvailable && gcAvailable
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 		Type:               ConditionReady,
 		Status:             conditionStatus(ready),
 		Reason:             conditionReason(ready, "AllComponentsReady", "ComponentsNotReady"),
+		Message:            conditionMessage(ready, "All components have at least one ready replica", "One or more components have no ready replicas"),
 		ObservedGeneration: gw.Generation,
 	})
 
@@ -322,6 +335,13 @@ func validateSpec(gw *batchv1alpha1.LLMBatchGateway) error {
 		return fmt.Errorf("processor cannot have both globalInferenceGateway and modelGateways configured")
 	}
 	return nil
+}
+
+func conditionMessage(ok bool, trueMsg, falseMsg string) string {
+	if ok {
+		return trueMsg
+	}
+	return falseMsg
 }
 
 var _ reconcile.Reconciler = (*LLMBatchGatewayReconciler)(nil)

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -24,7 +24,6 @@ func newTestGateway(name, namespace string) *batchv1alpha1.LLMBatchGateway {
 			SecretRef: batchv1alpha1.SecretReference{Name: "test-secrets"},
 			DBBackend: "postgresql",
 			FileStorage: &batchv1alpha1.FileStorageSpec{
-				Type: "s3",
 				S3: &batchv1alpha1.S3StorageSpec{
 					Region:   "us-east-1",
 					Endpoint: "https://s3.example.com",


### PR DESCRIPTION
## Summary

- **`fix(api): apply schema/types CRD conventions`** — add `+kubebuilder` markers for required fields, enums, defaults and min/max constraints; align Go types with Kubernetes conventions
- **`fix(controller): populate condition Message and add GCAvailable condition`** — all status conditions now carry a human-readable `Message`; adds missing `GCAvailable` condition
- **`fix(controller): add finalizer to gate CR deletion`** — adds `batch.llm-d.ai/finalizer` so future cleanup logic has a well-defined hook; continues reconciling in the same call instead of re-queuing
- **`fix(project): sync PROJECT file with actual module path`**
- **`chore(generated): regenerate deepcopy and CRD YAML manifests`**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status columns for API server and processor readiness reporting.
  * Enhanced TLS configuration with cert-manager integration and validation.
  * Garbage collection component readiness now included in overall status.

* **Bug Fixes**
  * Simplified S3 storage configuration (accessKeyId no longer required).
  * Port fields now validated as integers with proper constraints.
  * Standardized TLS CA certificate file field naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->