### PR TITLE
ci: build and push operator image to GHCR

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,65 @@
+name: Build and Push Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/batch-gateway-operator
+
+jobs:
+  build-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # branch push: floating "main" tag + "main-<short-sha>"
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=main-,enable=${{ github.ref == 'refs/heads/main' }}
+            # version tag push: semver tags + floating "latest"
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMG ?= ghcr.io/llm-d-incubation/batch-gw-operator:latest
+IMG ?= ghcr.io/opendatahub-io/batch-gateway-operator:latest
 CONTROLLER_GEN ?= go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.3
 ENVTEST ?= go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.21
 ENVTEST_K8S_VERSION ?= 1.33.0


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci-image.yml` to build and push a multi-arch operator image to GHCR on every push to `main` and on version tags
- Aligns `Makefile` default `IMG` from `batch-gw-operator` to `batch-gateway-operator` to match the new image name

## Image tag strategy

| Trigger | Tags produced |
|---|---|
| Push to `main` | `main` (floating) + `main-<short-sha>` |
| Push `v1.2.3` tag | `v1.2.3`, `1.2`, `latest` |

## Details

- Registry: `ghcr.io/llm-d-incubation/batch-gateway-operator`
- Platforms: `linux/amd64` + `linux/arm64` (via QEMU + Buildx)
- Auth: `GITHUB_TOKEN` — no extra secrets required
- Layer caching via GitHub Actions cache (`type=gha`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image building and publishing to the container registry on pushes to main branch and version tag releases.
  * Updated container image naming convention for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->