### PR TITLE
feat(controller): wire EventRecorder to emit Kubernetes Events on state transitions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,7 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := controller.NewLLMBatchGatewayReconciler(mgr.GetClient(), mgr.GetScheme(), helmRenderer).SetupWithManager(mgr); err != nil {
+	if err := controller.NewLLMBatchGatewayReconciler(mgr.GetClient(), mgr.GetScheme(), helmRenderer, mgr.GetEventRecorderFor("llmbatchgateway-controller")).SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "LLMBatchGateway")
 		os.Exit(1)
 	}

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,14 +72,16 @@ type LLMBatchGatewayReconciler struct {
 	client.Client
 	Scheme       *runtime.Scheme
 	HelmRenderer *HelmRenderer
+	Recorder     record.EventRecorder
 	secretFilter *secretWatchFilter
 }
 
-func NewLLMBatchGatewayReconciler(c client.Client, scheme *runtime.Scheme, helm *HelmRenderer) *LLMBatchGatewayReconciler {
+func NewLLMBatchGatewayReconciler(c client.Client, scheme *runtime.Scheme, helm *HelmRenderer, recorder record.EventRecorder) *LLMBatchGatewayReconciler {
 	return &LLMBatchGatewayReconciler{
 		Client:       c,
 		Scheme:       scheme,
 		HelmRenderer: helm,
+		Recorder:     recorder,
 		secretFilter: &secretWatchFilter{watched: make(map[string]struct{})},
 	}
 }
@@ -104,6 +107,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				ObservedGeneration: gw.Generation,
 			})
 		}
+		r.Recorder.Eventf(&gw, corev1.EventTypeWarning, "ValidationFailed", "Spec validation failed: %s", err)
 		if statusErr := r.Status().Update(ctx, &gw); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("updating status after validation failure: %w", statusErr)
 		}
@@ -130,6 +134,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				Message:            err.Error(),
 				ObservedGeneration: gw.Generation,
 			})
+			r.Recorder.Eventf(&gw, corev1.EventTypeWarning, reason, "%s", err)
 			if statusErr := r.Status().Update(ctx, &gw); statusErr != nil {
 				return ctrl.Result{}, fmt.Errorf("updating status after %s: %w", reason, statusErr)
 			}
@@ -157,6 +162,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			Message:            err.Error(),
 			ObservedGeneration: gw.Generation,
 		})
+		r.Recorder.Eventf(&gw, corev1.EventTypeWarning, "RenderFailed", "Helm chart render failed: %s", err)
 		if statusErr := r.Status().Update(ctx, &gw); statusErr != nil {
 			logger.Error(statusErr, "failed to update status after render failure")
 		}
@@ -175,6 +181,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				logger.V(1).Info("skipping resource (CRD not installed)", "kind", obj.GetKind(), "name", obj.GetName())
 				continue
 			}
+			r.Recorder.Eventf(&gw, corev1.EventTypeWarning, "ApplyFailed", "Failed to apply %s/%s: %s", obj.GetKind(), obj.GetName(), err)
 			return ctrl.Result{}, fmt.Errorf("applying %s/%s: %w", obj.GetKind(), obj.GetName(), err)
 		}
 		logger.V(2).Info("applied resource", "kind", obj.GetKind(), "name", obj.GetName())
@@ -321,6 +328,15 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 	})
 
 	ready := apiAvailable && procAvailable && gcAvailable
+
+	// Snapshot the previous Ready condition before overwriting it so we can
+	// detect transitions and emit an event only when the state changes.
+	var prevReadyStatus metav1.ConditionStatus
+	prevReady := meta.FindStatusCondition(gw.Status.Conditions, ConditionReady)
+	if prevReady != nil {
+		prevReadyStatus = prevReady.Status
+	}
+
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 		Type:               ConditionReady,
 		Status:             conditionStatus(ready),
@@ -328,6 +344,15 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 		Message:            conditionMessage(ready, "All components have at least one ready replica", "One or more components have no ready replicas"),
 		ObservedGeneration: gw.Generation,
 	})
+
+	newReadyStatus := conditionStatus(ready)
+	if prevReadyStatus != newReadyStatus {
+		if ready {
+			r.Recorder.Event(gw, corev1.EventTypeNormal, "Ready", "All components have at least one ready replica")
+		} else {
+			r.Recorder.Event(gw, corev1.EventTypeWarning, "NotReady", "One or more components have no ready replicas")
+		}
+	}
 
 	return r.Status().Update(ctx, gw)
 }

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -2,12 +2,14 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -59,7 +61,8 @@ func TestReconcile(t *testing.T) {
 		t.Fatalf("NewHelmRenderer() error: %v", err)
 	}
 
-	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer)
+	fakeRecorder := record.NewFakeRecorder(100)
+	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer, fakeRecorder)
 
 	t.Run("creates all child resources", func(t *testing.T) {
 		gw := newTestGateway("test-create")
@@ -376,6 +379,8 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("missing condition %s", condType)
 			}
 		}
+
+		assertEvent(t, fakeRecorder, corev1.EventTypeWarning, "ValidationFailed")
 	})
 
 	t.Run("sets ValidationFailed when both gateways configured", func(t *testing.T) {
@@ -447,6 +452,7 @@ func TestReconcile(t *testing.T) {
 				if c.Reason != "ReferenceNotPermitted" {
 					t.Errorf("Ready reason = %q, want ReferenceNotPermitted", c.Reason)
 				}
+				assertEvent(t, fakeRecorder, corev1.EventTypeWarning, "ReferenceNotPermitted")
 				return
 			}
 		}
@@ -498,6 +504,7 @@ func TestReconcile(t *testing.T) {
 				if c.Reason != "SecretRefImmutable" {
 					t.Errorf("Ready reason = %q, want SecretRefImmutable", c.Reason)
 				}
+				assertEvent(t, fakeRecorder, corev1.EventTypeWarning, "SecretRefImmutable")
 				return
 			}
 		}
@@ -611,4 +618,22 @@ func isOwnedByUID(refs []metav1.OwnerReference, uid types.UID) bool {
 		}
 	}
 	return false
+}
+
+// assertEvent drains the fake recorder channel and asserts that at least one
+// event contains both the expected eventType and reason substring.
+func assertEvent(t *testing.T, recorder *record.FakeRecorder, eventType, reason string) {
+	t.Helper()
+	for {
+		select {
+		case got := <-recorder.Events:
+			if strings.Contains(got, eventType) && strings.Contains(got, reason) {
+				return
+			}
+			// Drain other events that don't match (e.g. from previous subtests).
+		default:
+			t.Errorf("expected event with type %q and reason %q but none found", eventType, reason)
+			return
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Closes #15

- Add `record.EventRecorder` to `LLMBatchGatewayReconciler` and wire it via `mgr.GetEventRecorderFor("llmbatchgateway-controller")` in `cmd/main.go`
- Emit `Warning` events at every permanent reconciliation failure: `ValidationFailed`, `ReferenceNotPermitted`, `SecretRefImmutable`, `RenderFailed`, `ApplyFailed`
- Emit `Normal`/`Warning` events on `Ready` condition transitions only (`False→True` / `True→False`) — steady-state reconcile loops produce no event noise

RBAC already granted `events: create;patch` — no marker changes needed.

## How to verify

```
kubectl describe llmbatchgateway <name>
```

Events will appear in the `Events:` section for any reconciliation error or readiness change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event recording for LLMBatchGateway resources, providing detailed Kubernetes events for validation failures, resolution issues, and render errors.
  * Added readiness state transition events to improve observability of resource readiness changes.

* **Tests**
  * Added test coverage for event emission during reconciliation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->