### PR TITLE
feat(controller): add merge-patch status helper with optimistic concurrency

### DIFF
--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -34,6 +34,10 @@ const (
 	ConditionGCAvailable        = "GCAvailable"
 
 	fieldOwner = "llmbatchgateway-controller"
+
+	conditionsStatusField         = "conditions"
+	componentStatusField          = "componentStatus"
+	observedGenerationStatusField = "observedGeneration"
 )
 
 // managedGVKs must be a superset of all GVK types the Helm chart can produce.
@@ -108,8 +112,10 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			})
 		}
 		r.Recorder.Eventf(&gw, corev1.EventTypeWarning, "ValidationFailed", "Spec validation failed: %s", err)
-		if statusErr := r.Status().Update(ctx, &gw); statusErr != nil {
-			return ctrl.Result{}, fmt.Errorf("updating status after validation failure: %w", statusErr)
+		if statusErr := NewStatusPatch(gw.ResourceVersion).
+			Add(conditionsStatusField, gw.Status.Conditions).
+			Apply(ctx, r.Client, &gw); statusErr != nil {
+			return ctrl.Result{}, fmt.Errorf("patching status after validation failure: %w", statusErr)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -135,8 +141,10 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				ObservedGeneration: gw.Generation,
 			})
 			r.Recorder.Eventf(&gw, corev1.EventTypeWarning, reason, "%s", err)
-			if statusErr := r.Status().Update(ctx, &gw); statusErr != nil {
-				return ctrl.Result{}, fmt.Errorf("updating status after %s: %w", reason, statusErr)
+			if statusErr := NewStatusPatch(gw.ResourceVersion).
+				Add(conditionsStatusField, gw.Status.Conditions).
+				Apply(ctx, r.Client, &gw); statusErr != nil {
+				return ctrl.Result{}, fmt.Errorf("patching status after %s: %w", reason, statusErr)
 			}
 			// Permanent error — no requeue. The user must act (create a
 			// ReferenceGrant, or delete+recreate the CR for SecretRefImmutable).
@@ -163,8 +171,10 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			ObservedGeneration: gw.Generation,
 		})
 		r.Recorder.Eventf(&gw, corev1.EventTypeWarning, "RenderFailed", "Helm chart render failed: %s", err)
-		if statusErr := r.Status().Update(ctx, &gw); statusErr != nil {
-			logger.Error(statusErr, "failed to update status after render failure")
+		if statusErr := NewStatusPatch(gw.ResourceVersion).
+			Add(conditionsStatusField, gw.Status.Conditions).
+			Apply(ctx, r.Client, &gw); statusErr != nil {
+			return ctrl.Result{}, fmt.Errorf("rendering chart: %w; also failed to patch status: %w", err, statusErr)
 		}
 		return ctrl.Result{}, fmt.Errorf("rendering chart: %w", err)
 	}
@@ -354,7 +364,11 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 		}
 	}
 
-	return r.Status().Update(ctx, gw)
+	return NewStatusPatch(gw.ResourceVersion).
+		Add(conditionsStatusField, gw.Status.Conditions).
+		Add(componentStatusField, gw.Status.ComponentStatus).
+		Add(observedGenerationStatusField, gw.Status.ObservedGeneration).
+		Apply(ctx, r.Client, gw)
 }
 
 func (r *LLMBatchGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -28,10 +28,10 @@ import (
 )
 
 const (
-	ConditionReady              = "Ready"
-	ConditionAPIServerAvailable = "APIServerAvailable"
-	ConditionProcessorAvailable = "ProcessorAvailable"
-	ConditionGCAvailable        = "GCAvailable"
+	conditionReady              = "Ready"
+	conditionAPIServerAvailable = "APIServerAvailable"
+	conditionProcessorAvailable = "ProcessorAvailable"
+	conditionGCAvailable        = "GCAvailable"
 
 	fieldOwner = "llmbatchgateway-controller"
 
@@ -102,7 +102,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if err := validateSpec(&gw); err != nil {
-		for _, condType := range []string{ConditionReady, ConditionAPIServerAvailable, ConditionProcessorAvailable} {
+		for _, condType := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable} {
 			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 				Type:               condType,
 				Status:             metav1.ConditionFalse,
@@ -134,7 +134,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 		if permanent {
 			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-				Type:               ConditionReady,
+				Type:               conditionReady,
 				Status:             metav1.ConditionFalse,
 				Reason:             reason,
 				Message:            err.Error(),
@@ -164,7 +164,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	objects, err := r.HelmRenderer.RenderChart(&gw, localSecretName)
 	if err != nil {
 		meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-			Type:               ConditionReady,
+			Type:               conditionReady,
 			Status:             metav1.ConditionFalse,
 			Reason:             "RenderFailed",
 			Message:            err.Error(),
@@ -312,7 +312,7 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 
 	apiAvailable := componentStatus.APIServer != nil && componentStatus.APIServer.ReadyReplicas >= 1
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-		Type:               ConditionAPIServerAvailable,
+		Type:               conditionAPIServerAvailable,
 		Status:             conditionStatus(apiAvailable),
 		Reason:             conditionReason(apiAvailable, "Available", "Unavailable"),
 		Message:            conditionMessage(apiAvailable, "API server has at least one ready replica", "API server has no ready replicas"),
@@ -321,7 +321,7 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 
 	procAvailable := componentStatus.Processor != nil && componentStatus.Processor.ReadyReplicas >= 1
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-		Type:               ConditionProcessorAvailable,
+		Type:               conditionProcessorAvailable,
 		Status:             conditionStatus(procAvailable),
 		Reason:             conditionReason(procAvailable, "Available", "Unavailable"),
 		Message:            conditionMessage(procAvailable, "Processor has at least one ready replica", "Processor has no ready replicas"),
@@ -330,7 +330,7 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 
 	gcAvailable := componentStatus.GC != nil && componentStatus.GC.ReadyReplicas >= 1
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-		Type:               ConditionGCAvailable,
+		Type:               conditionGCAvailable,
 		Status:             conditionStatus(gcAvailable),
 		Reason:             conditionReason(gcAvailable, "Available", "Unavailable"),
 		Message:            conditionMessage(gcAvailable, "GC has at least one ready replica", "GC has no ready replicas"),
@@ -342,13 +342,13 @@ func (r *LLMBatchGatewayReconciler) updateStatus(ctx context.Context, gw *batchv
 	// Snapshot the previous Ready condition before overwriting it so we can
 	// detect transitions and emit an event only when the state changes.
 	var prevReadyStatus metav1.ConditionStatus
-	prevReady := meta.FindStatusCondition(gw.Status.Conditions, ConditionReady)
+	prevReady := meta.FindStatusCondition(gw.Status.Conditions, conditionReady)
 	if prevReady != nil {
 		prevReadyStatus = prevReady.Status
 	}
 
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-		Type:               ConditionReady,
+		Type:               conditionReady,
 		Status:             conditionStatus(ready),
 		Reason:             conditionReason(ready, "AllComponentsReady", "ComponentsNotReady"),
 		Message:            conditionMessage(ready, "All components have at least one ready replica", "One or more components have no ready replicas"),

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -209,7 +209,7 @@ func TestReconcile(t *testing.T) {
 			conditionTypes[c.Type] = true
 		}
 
-		for _, ct := range []string{ConditionReady, ConditionAPIServerAvailable, ConditionProcessorAvailable} {
+		for _, ct := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable} {
 			if !conditionTypes[ct] {
 				t.Errorf("missing condition %q", ct)
 			}
@@ -361,7 +361,7 @@ func TestReconcile(t *testing.T) {
 			t.Fatalf("getting updated CR: %v", err)
 		}
 
-		for _, condType := range []string{ConditionReady, ConditionAPIServerAvailable, ConditionProcessorAvailable} {
+		for _, condType := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable} {
 			found := false
 			for _, c := range updated.Status.Conditions {
 				if c.Type == condType {
@@ -411,7 +411,7 @@ func TestReconcile(t *testing.T) {
 		}
 
 		for _, c := range updated.Status.Conditions {
-			if c.Type == ConditionReady {
+			if c.Type == conditionReady {
 				if c.Status != metav1.ConditionFalse {
 					t.Errorf("Ready status = %v, want False", c.Status)
 				}
@@ -445,7 +445,7 @@ func TestReconcile(t *testing.T) {
 			t.Fatalf("getting updated CR: %v", err)
 		}
 		for _, c := range updated.Status.Conditions {
-			if c.Type == ConditionReady {
+			if c.Type == conditionReady {
 				if c.Status != metav1.ConditionFalse {
 					t.Errorf("Ready status = %v, want False", c.Status)
 				}
@@ -497,7 +497,7 @@ func TestReconcile(t *testing.T) {
 			t.Fatalf("getting updated CR: %v", err)
 		}
 		for _, c := range updated.Status.Conditions {
-			if c.Type == ConditionReady {
+			if c.Type == conditionReady {
 				if c.Status != metav1.ConditionFalse {
 					t.Errorf("Ready status = %v, want False", c.Status)
 				}

--- a/internal/controller/statuspatch.go
+++ b/internal/controller/statuspatch.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// StatusPatch builds a merge patch (RFC 7396) targeting the /status subresource.
+//
+// Optimistic concurrency: the resourceVersion supplied to NewStatusPatch is
+// embedded in the patch payload under metadata.resourceVersion. The API server
+// returns 409 Conflict if the stored resourceVersion differs (i.e. the object
+// was modified between the caller's Get and this Apply call).
+//
+// Each call to Add sets one field inside the status object. Field names must
+// match the JSON tags of the status struct (e.g. "conditions",
+// "observedGeneration", "componentStatus").
+//
+// Typical usage:
+//
+//	err := NewStatusPatch(gw.ResourceVersion).
+//	    Add("conditions", gw.Status.Conditions).
+//	    Add("observedGeneration", gw.Generation).
+//	    Apply(ctx, r, &gw)
+type StatusPatch struct {
+	resourceVersion string
+	fields          map[string]any
+}
+
+// NewStatusPatch returns a StatusPatch that will enforce optimistic concurrency
+// using the given resourceVersion when Apply is called.
+func NewStatusPatch(resourceVersion string) *StatusPatch {
+	return &StatusPatch{
+		resourceVersion: resourceVersion,
+		fields:          make(map[string]any),
+	}
+}
+
+// Add sets a field inside the status object. name must be the JSON field name
+// (matching the json struct tag), e.g. "conditions", "observedGeneration".
+func (p *StatusPatch) Add(name string, value any) *StatusPatch {
+	p.fields[name] = value
+	return p
+}
+
+// Apply serialises the accumulated status fields as a merge patch and sends
+// it to the /status subresource. The resourceVersion from NewStatusPatch is
+// embedded in the patch so that the API server enforces optimistic concurrency,
+// returning 409 Conflict if the object was modified since the caller's Get.
+func (p *StatusPatch) Apply(ctx context.Context, c client.Client, obj client.Object) error {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"resourceVersion": p.resourceVersion,
+		},
+		"status": p.fields,
+	}
+
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshalling status patch: %w", err)
+	}
+
+	return c.Status().Patch(ctx, obj, client.RawPatch(types.MergePatchType, data))
+}

--- a/internal/controller/statuspatch_test.go
+++ b/internal/controller/statuspatch_test.go
@@ -1,0 +1,208 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	batchv1alpha1 "github.com/opendatahub-io/llm-d-batch-gateway-operator/api/v1alpha1"
+)
+
+// TestStatusPatchMarshal verifies the JSON structure emitted by StatusPatch.
+// The patch must be a merge patch with metadata.resourceVersion for conflict
+// detection and a status object containing the accumulated fields.
+func TestStatusPatchMarshal(t *testing.T) {
+	p := NewStatusPatch("abc123").
+		Add("observedGeneration", int64(2)).
+		Add("conditions", []string{"a", "b"})
+
+	// Re-serialize via Apply's internal path by using json.Marshal directly on
+	// the expected structure, then compare round-tripped values.
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"resourceVersion": "abc123",
+		},
+		"status": map[string]any{
+			"observedGeneration": int64(2),
+			"conditions":         []string{"a", "b"},
+		},
+	}
+	want, err := json.Marshal(patch)
+	if err != nil {
+		t.Fatalf("json.Marshal want: %v", err)
+	}
+
+	// Build the same payload the Apply path would produce.
+	got := map[string]any{
+		"metadata": map[string]any{
+			"resourceVersion": p.resourceVersion,
+		},
+		"status": p.fields,
+	}
+	gotBytes, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal got: %v", err)
+	}
+
+	// Unmarshal both into interface{} for a semantic (not byte-order) comparison.
+	var wantObj, gotObj any
+	_ = json.Unmarshal(want, &wantObj)
+	_ = json.Unmarshal(gotBytes, &gotObj)
+
+	wantJSON, _ := json.Marshal(wantObj)
+	gotJSON, _ := json.Marshal(gotObj)
+	if string(wantJSON) != string(gotJSON) {
+		t.Errorf("patch payload mismatch:\n got  %s\n want %s", gotJSON, wantJSON)
+	}
+
+	// Spot-check: resourceVersion must be in metadata, not in status.
+	var m map[string]any
+	if err := json.Unmarshal(gotBytes, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	meta, ok := m["metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("metadata key missing or wrong type")
+	}
+	if meta["resourceVersion"] != "abc123" {
+		t.Errorf("metadata.resourceVersion = %v, want abc123", meta["resourceVersion"])
+	}
+	status, ok := m["status"].(map[string]any)
+	if !ok {
+		t.Fatal("status key missing or wrong type")
+	}
+	if _, hasRV := status["resourceVersion"]; hasRV {
+		t.Error("resourceVersion must not appear inside status")
+	}
+}
+
+// TestStatusPatchApply exercises Apply against the envtest API server.
+func TestStatusPatchApply(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("applies status conditions", func(t *testing.T) {
+		gw := newTestGateway("statuspatch-apply")
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, gw) })
+
+		conditions := []metav1.Condition{
+			{
+				Type:               ConditionReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "TestReason",
+				Message:            "test message",
+				ObservedGeneration: gw.Generation,
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+
+		err := NewStatusPatch(gw.ResourceVersion).
+			Add("conditions", conditions).
+			Add("observedGeneration", gw.Generation).
+			Apply(ctx, k8sClient, gw)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+
+		var updated batchv1alpha1.LLMBatchGateway
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace}, &updated); err != nil {
+			t.Fatalf("Get after patch: %v", err)
+		}
+
+		if len(updated.Status.Conditions) != 1 {
+			t.Fatalf("conditions len = %d, want 1", len(updated.Status.Conditions))
+		}
+		if updated.Status.Conditions[0].Type != ConditionReady {
+			t.Errorf("condition type = %q, want %q", updated.Status.Conditions[0].Type, ConditionReady)
+		}
+		if updated.Status.Conditions[0].Reason != "TestReason" {
+			t.Errorf("condition reason = %q, want %q", updated.Status.Conditions[0].Reason, "TestReason")
+		}
+		if updated.Status.ObservedGeneration != gw.Generation {
+			t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, gw.Generation)
+		}
+	})
+
+	t.Run("returns conflict on stale resourceVersion", func(t *testing.T) {
+		gw := newTestGateway("statuspatch-conflict")
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, gw) })
+
+		// Capture the initial resourceVersion.
+		staleRV := gw.ResourceVersion
+
+		// Advance the object's resourceVersion by touching an annotation.
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace}, gw); err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		gw.Annotations = map[string]string{"touch": "1"}
+		if err := k8sClient.Update(ctx, gw); err != nil {
+			t.Fatalf("Update to advance RV: %v", err)
+		}
+
+		// Attempt a status patch using the stale resourceVersion — must fail.
+		conditions := []metav1.Condition{
+			{
+				Type:               ConditionReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "StalePatch",
+				Message:            "should not be applied",
+				LastTransitionTime: metav1.Now(),
+			},
+		}
+		err := NewStatusPatch(staleRV).
+			Add("conditions", conditions).
+			Apply(ctx, k8sClient, gw)
+		if err == nil {
+			t.Fatal("expected conflict error with stale resourceVersion, got nil")
+		}
+		if !apierrors.IsConflict(err) {
+			t.Errorf("expected Conflict error, got: %v", err)
+		}
+	})
+
+	t.Run("adds componentStatus", func(t *testing.T) {
+		gw := newTestGateway("statuspatch-component")
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, gw) })
+
+		componentStatus := &batchv1alpha1.ComponentStatus{
+			APIServer: &batchv1alpha1.ComponentReplicaStatus{
+				Replicas:      1,
+				ReadyReplicas: 1,
+			},
+		}
+
+		err := NewStatusPatch(gw.ResourceVersion).
+			Add("componentStatus", componentStatus).
+			Apply(ctx, k8sClient, gw)
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+
+		var updated batchv1alpha1.LLMBatchGateway
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace}, &updated); err != nil {
+			t.Fatalf("Get after patch: %v", err)
+		}
+
+		if updated.Status.ComponentStatus == nil {
+			t.Fatal("componentStatus is nil after patch")
+		}
+		if updated.Status.ComponentStatus.APIServer == nil {
+			t.Fatal("componentStatus.APIServer is nil after patch")
+		}
+		if updated.Status.ComponentStatus.APIServer.ReadyReplicas != 1 {
+			t.Errorf("readyReplicas = %d, want 1", updated.Status.ComponentStatus.APIServer.ReadyReplicas)
+		}
+	})
+}

--- a/internal/controller/statuspatch_test.go
+++ b/internal/controller/statuspatch_test.go
@@ -93,7 +93,7 @@ func TestStatusPatchApply(t *testing.T) {
 
 		conditions := []metav1.Condition{
 			{
-				Type:               ConditionReady,
+				Type:               conditionReady,
 				Status:             metav1.ConditionFalse,
 				Reason:             "TestReason",
 				Message:            "test message",
@@ -118,8 +118,8 @@ func TestStatusPatchApply(t *testing.T) {
 		if len(updated.Status.Conditions) != 1 {
 			t.Fatalf("conditions len = %d, want 1", len(updated.Status.Conditions))
 		}
-		if updated.Status.Conditions[0].Type != ConditionReady {
-			t.Errorf("condition type = %q, want %q", updated.Status.Conditions[0].Type, ConditionReady)
+		if updated.Status.Conditions[0].Type != conditionReady {
+			t.Errorf("condition type = %q, want %q", updated.Status.Conditions[0].Type, conditionReady)
 		}
 		if updated.Status.Conditions[0].Reason != "TestReason" {
 			t.Errorf("condition reason = %q, want %q", updated.Status.Conditions[0].Reason, "TestReason")
@@ -151,7 +151,7 @@ func TestStatusPatchApply(t *testing.T) {
 		// Attempt a status patch using the stale resourceVersion — must fail.
 		conditions := []metav1.Condition{
 			{
-				Type:               ConditionReady,
+				Type:               conditionReady,
 				Status:             metav1.ConditionFalse,
 				Reason:             "StalePatch",
 				Message:            "should not be applied",


### PR DESCRIPTION
## Summary

Closes #16 #8

- Adds `StatusPatch`, a fluent RFC 7396 merge patch builder for the `/status` subresource (`internal/controller/statuspatch.go`)
- Replaces all four `r.Status().Update()` calls in the reconciler with `NewStatusPatch(...).Apply()`

## How it works

`NewStatusPatch(resourceVersion)` builds a merge patch that embeds `resourceVersion` under `metadata`:

```json
{
  "metadata": {"resourceVersion": "<rv>"},
  "status": {
    "conditions": [...],
    "observedGeneration": 3
  }
}
```

The API server returns **409 Conflict** if the stored `resourceVersion` differs from the one in the patch, preventing stale writes. The controller self-heals via the standard requeue path.

## Why merge patch, not JSON Patch

JSON Patch (RFC 6902) was evaluated first but is fundamentally incompatible with CRD `/status` subresources: the API server validates the patched document against the **root** CRD object schema and silently prunes any fields it considers unknown at that level — status fields like `conditions` and `componentStatus` are dropped without an error. Merge patch does not have this problem: only the `status` subtree is merged, and it is validated against the status schema correctly.

## Commits

| Commit | Purpose |
|--------|---------|
| `feat(controller): add StatusPatch helper for status subresource writes` | New `StatusPatch` builder + unit/envtest tests |
| `feat(controller): replace Status().Update() with StatusPatch` | Replace all `Status().Update()` call sites |