### PR TITLE
chore(ci): add unit test and linting jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,24 @@ on:
       - 'Makefile'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Lint
+        run: make lint
+
   test:
-    name: Lint & Test
+    name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,64 @@
+version: "2"
+
+run:
+  timeout: 5m
+  allow-parallel-runners: true
+
+formatters:
+  enable:
+    - goimports
+    - gofmt
+
+linters:
+  enable:
+    - bodyclose
+    - copyloopvar
+    - dupword
+    - durationcheck
+    - errcheck
+    - fatcontext
+    - goconst
+    - gocritic
+    - govet
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nilnil
+    - perfsprint
+    - prealloc
+    - revive
+    - staticcheck
+    - unparam
+    - unused
+    - unconvert
+  exclusions:
+    presets:
+      - comments        # suppress missing comment violations on packages and exported symbols
+      - std-error-handling  # suppress unchecked errors on well-known stdlib patterns (e.g. Close())
+  settings:
+    revive: # see https://github.com/mgechev/revive#available-rules for all options
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: errorf
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
+
+issues:
+  # do not limit the number of issues, ensure even identical are reported
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,22 @@ LOCALBIN ?= $(shell pwd)/bin/k8s
 build:
 	go build -o bin/manager ./cmd/
 
+## Lint & Format
+
+GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+
+.PHONY: fmt
+fmt:
+	go fmt ./...
+
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: lint
+lint:
+	$(GOLANGCI_LINT) run
+
 ## Code Generation
 
 .PHONY: manifests

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -38,7 +38,7 @@ type LLMBatchGatewayList struct {
 }
 
 // LLMBatchGatewaySpec defines the desired state of the batch gateway deployment.
-// +kubebuilder:validation:XValidation:rule="self.secretRef.name != ''",message="spec.secretRef.name is required"
+// +kubebuilder:validation:XValidation:rule="size(self.secretRef.name) > 0",message="spec.secretRef.name is required"
 type LLMBatchGatewaySpec struct {
 	// SecretRef references the Kubernetes Secret that holds runtime credentials
 	// (database URL, S3 keys, inference API key, etc.).
@@ -436,8 +436,8 @@ type OTELSpec struct {
 // --- TLS ---
 
 // TLSSpec configures TLS termination for the API server.
-// +kubebuilder:validation:XValidation:rule="!self.enabled || self.secretName != '' || has(self.certManager)",message="tls.secretName or tls.certManager must be set when tls.enabled is true"
-// +kubebuilder:validation:XValidation:rule="!(self.secretName != '' && has(self.certManager))",message="tls.secretName and tls.certManager are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!self.enabled || size(self.secretName) > 0 || has(self.certManager)",message="tls.secretName or tls.certManager must be set when tls.enabled is true"
+// +kubebuilder:validation:XValidation:rule="!(size(self.secretName) > 0 && has(self.certManager))",message="tls.secretName and tls.certManager are mutually exclusive"
 type TLSSpec struct {
 	// Enabled controls whether TLS termination is configured for the API server.
 	Enabled bool `json:"enabled,omitempty"`
@@ -453,7 +453,7 @@ type TLSSpec struct {
 }
 
 // CertManagerSpec configures automatic certificate provisioning via cert-manager.
-// +kubebuilder:validation:XValidation:rule="self.issuerName != ''",message="certManager.issuerName must be set"
+// +kubebuilder:validation:XValidation:rule="size(self.issuerName) > 0",message="certManager.issuerName must be set"
 type CertManagerSpec struct {
 	// IssuerName is the name of the cert-manager Issuer or ClusterIssuer.
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -756,7 +756,7 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: certManager.issuerName must be set
-                      rule: self.issuerName != ''
+                      rule: size(self.issuerName) > 0
                   enabled:
                     description: Enabled controls whether TLS termination is configured
                       for the API server.
@@ -771,9 +771,9 @@ spec:
                 x-kubernetes-validations:
                 - message: tls.secretName or tls.certManager must be set when tls.enabled
                     is true
-                  rule: '!self.enabled || self.secretName != '''' || has(self.certManager)'
+                  rule: '!self.enabled || size(self.secretName) > 0 || has(self.certManager)'
                 - message: tls.secretName and tls.certManager are mutually exclusive
-                  rule: '!(self.secretName != '''' && has(self.certManager))'
+                  rule: '!(size(self.secretName) > 0 && has(self.certManager))'
             required:
             - apiServer
             - gc
@@ -782,7 +782,7 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: spec.secretRef.name is required
-              rule: self.secretRef.name != ''
+              rule: size(self.secretRef.name) > 0
           status:
             description: Status defines the observed state of LLMBatchGateway.
             properties:

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -32,10 +32,7 @@ func NewHelmRenderer(chartPath string) (*HelmRenderer, error) {
 }
 
 func (h *HelmRenderer) RenderChart(gw *batchv1alpha1.LLMBatchGateway, secretName string) ([]*unstructured.Unstructured, error) {
-	vals, err := specToHelmValues(gw, secretName)
-	if err != nil {
-		return nil, fmt.Errorf("converting spec to helm values: %w", err)
-	}
+	vals := specToHelmValues(gw, secretName)
 
 	releaseOpts := chartutil.ReleaseOptions{
 		Name:      gw.Name,
@@ -78,7 +75,7 @@ func (h *HelmRenderer) RenderChart(gw *batchv1alpha1.LLMBatchGateway, secretName
 	return objects, nil
 }
 
-func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) (map[string]interface{}, error) {
+func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[string]interface{} {
 	vals := map[string]interface{}{}
 
 	// --- Global ---
@@ -317,7 +314,7 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) (map
 		vals["prometheusRule"] = pr
 	}
 
-	return vals, nil
+	return vals
 }
 
 // splitImage splits an image reference into (repository, tag).

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -129,10 +129,7 @@ func TestSpecToHelmValues(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	t.Run("global secret name", func(t *testing.T) {
 		global, ok := vals["global"].(map[string]interface{})
@@ -214,10 +211,7 @@ func TestSpecToHelmValues_Monitoring(t *testing.T) {
 	gw := minimalGateway()
 	gw.Spec.Monitoring = &batchv1alpha1.MonitoringSpec{Enabled: true}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	t.Run("service monitor enabled", func(t *testing.T) {
 		apiserver := vals["apiserver"].(map[string]interface{})
@@ -246,10 +240,7 @@ func TestSpecToHelmValues_TLS(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	tls := apiserver["tls"].(map[string]interface{})
@@ -280,10 +271,7 @@ func TestSpecToHelmValues_HTTPRoute(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	hr := apiserver["httpRoute"].(map[string]interface{})
@@ -422,10 +410,7 @@ func TestSpecToHelmValues_Logging(t *testing.T) {
 		Logging: &batchv1alpha1.LoggingConfig{Verbosity: 4},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	t.Run("apiserver logging verbosity", func(t *testing.T) {
 		apiserver := vals["apiserver"].(map[string]interface{})
@@ -469,10 +454,7 @@ func TestSpecToHelmValues_FSStorage(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	global := vals["global"].(map[string]interface{})
 	fc := global["fileClient"].(map[string]interface{})
@@ -508,10 +490,7 @@ func TestSpecToHelmValues_OTEL(t *testing.T) {
 		PostgresqlTracing: true,
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	global := vals["global"].(map[string]interface{})
 	otel := global["otel"].(map[string]interface{})
@@ -537,10 +516,7 @@ func TestSpecToHelmValues_TLSSecretName(t *testing.T) {
 		SecretName: "my-tls-secret",
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	tls := apiserver["tls"].(map[string]interface{})
@@ -560,10 +536,7 @@ func TestSpecToHelmValues_TLSDNSNames(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	tls := apiserver["tls"].(map[string]interface{})
@@ -590,10 +563,7 @@ func TestSpecToHelmValues_HTTPRouteAnnotations(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	hr := apiserver["httpRoute"].(map[string]interface{})
@@ -613,10 +583,7 @@ func TestSpecToHelmValues_ModelGateways(t *testing.T) {
 		"model-a": {URL: "http://model-a:8000", RequestTimeout: "2m"},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	processor := vals["processor"].(map[string]interface{})
 	config := processor["config"].(map[string]interface{})
@@ -637,10 +604,7 @@ func TestSpecToHelmValues_PrometheusRule(t *testing.T) {
 		Labels:  map[string]string{"prometheus": "kube-prometheus"},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	pr := vals["prometheusRule"].(map[string]interface{})
 	if got := pr["enabled"]; got != true {
@@ -655,12 +619,12 @@ func TestSpecToHelmValues_PrometheusRule(t *testing.T) {
 func TestSpecToHelmValues_APIServerConfig(t *testing.T) {
 	gw := minimalGateway()
 	gw.Spec.APIServer.Config = &batchv1alpha1.APIServerConfigSpec{
-		Port:               8080,
-		ObservabilityPort:  9090,
-		ReadTimeoutSeconds: 30,
+		Port:                8080,
+		ObservabilityPort:   9090,
+		ReadTimeoutSeconds:  30,
 		WriteTimeoutSeconds: 60,
-		IdleTimeoutSeconds: 120,
-		EnablePprof:        true,
+		IdleTimeoutSeconds:  120,
+		EnablePprof:         true,
 		BatchAPI: &batchv1alpha1.BatchAPIConfig{
 			EventTTLSeconds:    3600,
 			PassThroughHeaders: []string{"X-Request-ID", "Authorization"},
@@ -672,10 +636,7 @@ func TestSpecToHelmValues_APIServerConfig(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	config := apiserver["config"].(map[string]interface{})
@@ -733,10 +694,7 @@ func TestSpecToHelmValues_ProcessorConfig(t *testing.T) {
 		EnablePprof:                    true,
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	processor := vals["processor"].(map[string]interface{})
 	config := processor["config"].(map[string]interface{})
@@ -774,10 +732,7 @@ func TestSpecToHelmValues_GCConfig(t *testing.T) {
 		MaxConcurrency: 10,
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	gc := vals["gc"].(map[string]interface{})
 	config := gc["config"].(map[string]interface{})
@@ -798,10 +753,7 @@ func TestSpecToHelmValues_InferenceGatewayMaxRetries(t *testing.T) {
 		MaxRetries: &maxRetries,
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	processor := vals["processor"].(map[string]interface{})
 	config := processor["config"].(map[string]interface{})
@@ -824,10 +776,7 @@ func TestSpecToHelmValues_ResourceRequirements(t *testing.T) {
 		},
 	}
 
-	vals, err := specToHelmValues(gw, testSecretName(gw))
-	if err != nil {
-		t.Fatalf("specToHelmValues() error: %v", err)
-	}
+	vals := specToHelmValues(gw, testSecretName(gw))
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	res := apiserver["resources"].(map[string]interface{})

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -436,10 +436,10 @@ func validateSpec(gw *batchv1alpha1.LLMBatchGateway) error {
 	hasGlobal := gw.Spec.Processor.GlobalInferenceGateway != nil
 	hasModel := len(gw.Spec.Processor.ModelGateways) > 0
 	if !hasGlobal && !hasModel {
-		return fmt.Errorf("processor must have either globalInferenceGateway or modelGateways configured")
+		return errors.New("processor must have either globalInferenceGateway or modelGateways configured")
 	}
 	if hasGlobal && hasModel {
-		return fmt.Errorf("processor cannot have both globalInferenceGateway and modelGateways configured")
+		return errors.New("processor cannot have both globalInferenceGateway and modelGateways configured")
 	}
 	return nil
 }

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -14,11 +14,13 @@ import (
 	batchv1alpha1 "github.com/opendatahub-io/llm-d-batch-gateway-operator/api/v1alpha1"
 )
 
-func newTestGateway(name, namespace string) *batchv1alpha1.LLMBatchGateway {
+const llmBatchGatewayKind = "LLMBatchGateway"
+
+func newTestGateway(name string) *batchv1alpha1.LLMBatchGateway {
 	return &batchv1alpha1.LLMBatchGateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: "default",
 		},
 		Spec: batchv1alpha1.LLMBatchGatewaySpec{
 			SecretRef: corev1.SecretReference{Name: "test-secrets"},
@@ -60,7 +62,7 @@ func TestReconcile(t *testing.T) {
 	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer)
 
 	t.Run("creates all child resources", func(t *testing.T) {
-		gw := newTestGateway("test-create", "default")
+		gw := newTestGateway("test-create")
 		if err := k8sClient.Create(ctx, gw); err != nil {
 			t.Fatalf("creating CR: %v", err)
 		}
@@ -141,7 +143,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("sets owner references", func(t *testing.T) {
-		gw := newTestGateway("test-owner", "default")
+		gw := newTestGateway("test-owner")
 		if err := k8sClient.Create(ctx, gw); err != nil {
 			t.Fatalf("creating CR: %v", err)
 		}
@@ -167,7 +169,7 @@ func TestReconcile(t *testing.T) {
 			}
 			found := false
 			for _, ref := range d.OwnerReferences {
-				if ref.UID == gw.UID && ref.Kind == "LLMBatchGateway" && ref.Controller != nil && *ref.Controller {
+				if ref.UID == gw.UID && ref.Kind == llmBatchGatewayKind && ref.Controller != nil && *ref.Controller {
 					found = true
 					break
 				}
@@ -179,7 +181,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("sets status conditions", func(t *testing.T) {
-		gw := newTestGateway("test-status", "default")
+		gw := newTestGateway("test-status")
 		if err := k8sClient.Create(ctx, gw); err != nil {
 			t.Fatalf("creating CR: %v", err)
 		}
@@ -216,7 +218,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("updates on spec change", func(t *testing.T) {
-		gw := newTestGateway("test-update", "default")
+		gw := newTestGateway("test-update")
 		if err := k8sClient.Create(ctx, gw); err != nil {
 			t.Fatalf("creating CR: %v", err)
 		}
@@ -267,7 +269,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("deletes orphaned resources on spec change", func(t *testing.T) {
-		gw := newTestGateway("test-orphan", "default")
+		gw := newTestGateway("test-orphan")
 		gw.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: true}
 		if err := k8sClient.Create(ctx, gw); err != nil {
 			t.Fatalf("creating CR: %v", err)
@@ -334,7 +336,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("sets ValidationFailed when no inference gateway configured", func(t *testing.T) {
-		gw := newTestGateway("test-validation-none", "default")
+		gw := newTestGateway("test-validation-none")
 		gw.Spec.Processor.GlobalInferenceGateway = nil
 		gw.Spec.Processor.ModelGateways = nil
 		if err := k8sClient.Create(ctx, gw); err != nil {
@@ -377,7 +379,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("sets ValidationFailed when both gateways configured", func(t *testing.T) {
-		gw := newTestGateway("test-validation-both", "default")
+		gw := newTestGateway("test-validation-both")
 		gw.Spec.Processor.GlobalInferenceGateway = &batchv1alpha1.InferenceGatewaySpec{
 			URL: "http://global:8000",
 		}
@@ -418,7 +420,7 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("sets ReferenceNotPermitted when no ReferenceGrant exists", func(t *testing.T) {
-		gw := newTestGateway("test-refnotpermitted", "default")
+		gw := newTestGateway("test-refnotpermitted")
 		// Cross-namespace secretRef — no ReferenceGrant is present.
 		gw.Spec.SecretRef = corev1.SecretReference{Name: "src-secret", Namespace: "other-ns"}
 		if err := k8sClient.Create(ctx, gw); err != nil {
@@ -469,7 +471,7 @@ func TestReconcile(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = k8sClient.Delete(ctx, existingCopy) })
 
-		gw := newTestGateway(gwName, "default")
+		gw := newTestGateway(gwName)
 		// Cross-namespace secretRef pointing at a different secret than the copy.
 		gw.Spec.SecretRef = corev1.SecretReference{Name: "new-secret", Namespace: "other-ns"}
 		if err := k8sClient.Create(ctx, gw); err != nil {
@@ -503,9 +505,9 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("does not delete resources owned by a different CR", func(t *testing.T) {
-		gwA := newTestGateway("test-orphan-a", "default")
+		gwA := newTestGateway("test-orphan-a")
 		gwA.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: true}
-		gwB := newTestGateway("test-orphan-b", "default")
+		gwB := newTestGateway("test-orphan-b")
 		gwB.Spec.Grafana = &batchv1alpha1.GrafanaSpec{Enabled: true}
 
 		if err := k8sClient.Create(ctx, gwA); err != nil {
@@ -586,7 +588,7 @@ func TestConditionHelpers(t *testing.T) {
 }
 
 func TestIsOwnedBy(t *testing.T) {
-	gw := newTestGateway("gw", "default")
+	gw := newTestGateway("gw")
 	gw.UID = "test-uid"
 
 	owned := &corev1.ConfigMap{}

--- a/internal/controller/secret_sync.go
+++ b/internal/controller/secret_sync.go
@@ -31,11 +31,11 @@ const (
 //
 // Cross-namespace case (secretRef.Namespace != gw.Namespace):
 //
-//	1. Verifies a ReferenceGrant exists in secretRef.Namespace that permits
-//	   this LLMBatchGateway (in gw.Namespace) to reference the named Secret.
-//	2. Reads the source Secret.
-//	3. Creates or updates a managed copy in gw.Namespace owned by the CR.
-//	4. Returns the name of the managed copy.
+//  1. Verifies a ReferenceGrant exists in secretRef.Namespace that permits
+//     this LLMBatchGateway (in gw.Namespace) to reference the named Secret.
+//  2. Reads the source Secret.
+//  3. Creates or updates a managed copy in gw.Namespace owned by the CR.
+//  4. Returns the name of the managed copy.
 //
 // Returns (localSecretName, nil) on success.
 // Returns ("", ErrReferenceNotPermitted) when no valid ReferenceGrant exists.
@@ -62,8 +62,8 @@ func (r *LLMBatchGatewayReconciler) resolveSecret(
 		wantAnnotation := fmt.Sprintf("%s/%s", secretNS, ref.Name)
 		if got := existing.Annotations["batch.llm-d.ai/copied-from"]; got != wantAnnotation {
 			return "", &SecretRefImmutableError{
-				OldRef:      got,
-				NewRef:      wantAnnotation,
+				OldRef: got,
+				NewRef: wantAnnotation,
 			}
 		}
 	}
@@ -199,8 +199,8 @@ func (r *LLMBatchGatewayReconciler) syncSecretCopy(
 // managed Secret copy already exists. The controller refuses to reconcile
 // until the CR is deleted and recreated with the new secretRef.
 type SecretRefImmutableError struct {
-	OldRef      string
-	NewRef      string
+	OldRef string
+	NewRef string
 }
 
 func (e *SecretRefImmutableError) Error() string {
@@ -217,7 +217,7 @@ type ReferenceNotPermittedError struct {
 }
 
 func (e *ReferenceNotPermittedError) Error() string {
-	return fmt.Sprintf("reference not permitted: %s", e.Reason)
+	return "reference not permitted: " + e.Reason
 }
 
 func newReferenceNotPermittedError(gatewayName, secretName, secretNamespace, reason string) *ReferenceNotPermittedError {

--- a/internal/controller/secret_sync_test.go
+++ b/internal/controller/secret_sync_test.go
@@ -18,6 +18,8 @@ import (
 	batchv1alpha1 "github.com/opendatahub-io/llm-d-batch-gateway-operator/api/v1alpha1"
 )
 
+const testSecretValue = "value"
+
 // buildScheme returns a Scheme with all types needed by secret_sync.go.
 func buildScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -34,10 +36,10 @@ func buildScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-// makeGrant builds a ReferenceGrant in secretNamespace that allows
+// makeGrant builds a ReferenceGrant in "creds-ns" that allows
 // LLMBatchGateways in fromNamespace to reference a Secret.
 // Pass secretName="" to get a wildcard To entry.
-func makeGrant(name, secretNamespace, fromNamespace, secretName string) *gatewayv1beta1.ReferenceGrant {
+func makeGrant(name, fromNamespace, secretName string) *gatewayv1beta1.ReferenceGrant {
 	to := gatewayv1beta1.ReferenceGrantTo{
 		Group: corev1.GroupName,
 		Kind:  "Secret",
@@ -49,7 +51,7 @@ func makeGrant(name, secretNamespace, fromNamespace, secretName string) *gateway
 	return &gatewayv1beta1.ReferenceGrant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: secretNamespace,
+			Namespace: "creds-ns",
 		},
 		Spec: gatewayv1beta1.ReferenceGrantSpec{
 			From: []gatewayv1beta1.ReferenceGrantFrom{{
@@ -74,28 +76,28 @@ func TestReferenceGrantPermits(t *testing.T) {
 	}{
 		{
 			name:          "exact match",
-			grant:         makeGrant("g", "creds-ns", "default", "my-secret"),
+			grant:         makeGrant("g", "default", "my-secret"),
 			fromNamespace: "default",
 			secretName:    "my-secret",
 			want:          true,
 		},
 		{
 			name:          "wildcard to (no name filter)",
-			grant:         makeGrant("g", "creds-ns", "default", ""),
+			grant:         makeGrant("g", "default", ""),
 			fromNamespace: "default",
 			secretName:    "any-secret",
 			want:          true,
 		},
 		{
 			name:          "wrong secret name",
-			grant:         makeGrant("g", "creds-ns", "default", "other-secret"),
+			grant:         makeGrant("g", "default", "other-secret"),
 			fromNamespace: "default",
 			secretName:    "my-secret",
 			want:          false,
 		},
 		{
 			name:          "wrong from namespace",
-			grant:         makeGrant("g", "creds-ns", "other-ns", "my-secret"),
+			grant:         makeGrant("g", "other-ns", "my-secret"),
 			fromNamespace: "default",
 			secretName:    "my-secret",
 			want:          false,
@@ -160,11 +162,11 @@ func TestResolveSecret(t *testing.T) {
 
 	srcSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: credsNS},
-		Data:       map[string][]byte{"key": []byte("value")},
+		Data:       map[string][]byte{"key": []byte(testSecretValue)},
 	}
 
 	gwBase := func(gwName, secretNS, secretNameOverride string) *batchv1alpha1.LLMBatchGateway {
-		gw := newTestGateway(gwName, gwNamespace)
+		gw := newTestGateway(gwName)
 		gw.UID = types.UID(gwName + "-uid")
 		sName := secretName
 		if secretNameOverride != "" {
@@ -230,7 +232,7 @@ func TestResolveSecret(t *testing.T) {
 
 	t.Run("cross-namespace with grant for wrong secret returns error", func(t *testing.T) {
 		s := buildScheme(t)
-		grant := makeGrant("test-grant", credsNS, gwNamespace, "different-secret")
+		grant := makeGrant("test-grant", gwNamespace, "different-secret")
 		c := fake.NewClientBuilder().WithScheme(s).WithObjects(srcSecret, grant).Build()
 		r := &LLMBatchGatewayReconciler{Client: c, Scheme: s}
 
@@ -258,9 +260,9 @@ func TestResolveSecret(t *testing.T) {
 	t.Run("cross-namespace with exact ReferenceGrant copies secret", func(t *testing.T) {
 		src := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "src-secret-exact", Namespace: credsNS},
-			Data:       map[string][]byte{"key": []byte("value")},
+			Data:       map[string][]byte{"key": []byte(testSecretValue)},
 		}
-		grant := makeGrant("grant-exact", credsNS, gwNamespace, src.Name)
+		grant := makeGrant("grant-exact", gwNamespace, src.Name)
 
 		if err := k8sClient.Create(ctx, src); err != nil {
 			t.Fatalf("creating src secret: %v", err)
@@ -290,8 +292,8 @@ func TestResolveSecret(t *testing.T) {
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: wantName, Namespace: gwNamespace}, &copied); err != nil {
 			t.Fatalf("getting secret copy: %v", err)
 		}
-		if string(copied.Data["key"]) != "value" {
-			t.Errorf("copy data[key] = %q, want %q", copied.Data["key"], "value")
+		if string(copied.Data["key"]) != testSecretValue {
+			t.Errorf("copy data[key] = %q, want %q", copied.Data["key"], testSecretValue)
 		}
 		wantAnnotation := credsNS + "/" + src.Name
 		if copied.Annotations["batch.llm-d.ai/copied-from"] != wantAnnotation {
@@ -312,9 +314,9 @@ func TestResolveSecret(t *testing.T) {
 	t.Run("cross-namespace with wildcard ReferenceGrant copies secret", func(t *testing.T) {
 		src := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "src-secret-wildcard", Namespace: credsNS},
-			Data:       map[string][]byte{"key": []byte("value")},
+			Data:       map[string][]byte{"key": []byte(testSecretValue)},
 		}
-		grant := makeGrant("grant-wildcard", credsNS, gwNamespace, "") // wildcard
+		grant := makeGrant("grant-wildcard", gwNamespace, "") // wildcard
 
 		if err := k8sClient.Create(ctx, src); err != nil {
 			t.Fatalf("creating src secret: %v", err)
@@ -344,8 +346,8 @@ func TestResolveSecret(t *testing.T) {
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: wantName, Namespace: gwNamespace}, &copied); err != nil {
 			t.Fatalf("getting secret copy: %v", err)
 		}
-		if string(copied.Data["key"]) != "value" {
-			t.Errorf("copy data[key] = %q, want %q", copied.Data["key"], "value")
+		if string(copied.Data["key"]) != testSecretValue {
+			t.Errorf("copy data[key] = %q, want %q", copied.Data["key"], testSecretValue)
 		}
 		wantAnnotation := credsNS + "/" + src.Name
 		if copied.Annotations["batch.llm-d.ai/copied-from"] != wantAnnotation {
@@ -373,7 +375,7 @@ func TestResolveSecret(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "src-immutable-2", Namespace: credsNS},
 			Data:       map[string][]byte{"key": []byte("v2")},
 		}
-		grant := makeGrant("grant-immutable", credsNS, gwNamespace, "") // wildcard covers both
+		grant := makeGrant("grant-immutable", gwNamespace, "") // wildcard covers both
 
 		for _, obj := range []client.Object{src1, src2, grant} {
 			if err := k8sClient.Create(ctx, obj); err != nil {

--- a/internal/controller/secret_watch_filter_test.go
+++ b/internal/controller/secret_watch_filter_test.go
@@ -16,8 +16,8 @@ func newFilter(entries ...string) *secretWatchFilter {
 	return f
 }
 
-func secretObj(ns, name string) *corev1.Secret {
-	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+func secretObj(name string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: name}}
 }
 
 func TestSecretWatchFilter_Matches(t *testing.T) {
@@ -59,40 +59,40 @@ func TestSecretWatchFilter_AddRemove(t *testing.T) {
 
 func TestSecretWatchFilter_Create(t *testing.T) {
 	f := newFilter("ns", "tracked")
-	if !f.Create(event.CreateEvent{Object: secretObj("ns", "tracked")}) {
+	if !f.Create(event.CreateEvent{Object: secretObj("tracked")}) {
 		t.Error("Create: expected true for tracked secret")
 	}
-	if f.Create(event.CreateEvent{Object: secretObj("ns", "other")}) {
+	if f.Create(event.CreateEvent{Object: secretObj("other")}) {
 		t.Error("Create: expected false for untracked secret")
 	}
 }
 
 func TestSecretWatchFilter_Update(t *testing.T) {
 	f := newFilter("ns", "tracked")
-	if !f.Update(event.UpdateEvent{ObjectNew: secretObj("ns", "tracked")}) {
+	if !f.Update(event.UpdateEvent{ObjectNew: secretObj("tracked")}) {
 		t.Error("Update: expected true for tracked secret")
 	}
-	if f.Update(event.UpdateEvent{ObjectNew: secretObj("ns", "other")}) {
+	if f.Update(event.UpdateEvent{ObjectNew: secretObj("other")}) {
 		t.Error("Update: expected false for untracked secret")
 	}
 }
 
 func TestSecretWatchFilter_Delete(t *testing.T) {
 	f := newFilter("ns", "tracked")
-	if !f.Delete(event.DeleteEvent{Object: secretObj("ns", "tracked")}) {
+	if !f.Delete(event.DeleteEvent{Object: secretObj("tracked")}) {
 		t.Error("Delete: expected true for tracked secret")
 	}
-	if f.Delete(event.DeleteEvent{Object: secretObj("ns", "other")}) {
+	if f.Delete(event.DeleteEvent{Object: secretObj("other")}) {
 		t.Error("Delete: expected false for untracked secret")
 	}
 }
 
 func TestSecretWatchFilter_Generic(t *testing.T) {
 	f := newFilter("ns", "tracked")
-	if !f.Generic(event.GenericEvent{Object: secretObj("ns", "tracked")}) {
+	if !f.Generic(event.GenericEvent{Object: secretObj("tracked")}) {
 		t.Error("Generic: expected true for tracked secret")
 	}
-	if f.Generic(event.GenericEvent{Object: secretObj("ns", "other")}) {
+	if f.Generic(event.GenericEvent{Object: secretObj("other")}) {
 		t.Error("Generic: expected false for untracked secret")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `fmt`, `vet`, and `lint` Makefile targets using golangci-lint v2 with a configuration adapted from llm-d-inference-scheduler
- Add a dedicated `lint` job to the CI workflow so linting runs on every PR alongside the existing test job
- Fix all issues surfaced by the linter (`perfsprint`, `unparam`, `goconst`) and update CEL validation rules in kubebuilder markers to avoid `gofmt` mangling

Fixes #9