### PR TITLE
feat(controller): add periodic re-sync via --sync-period flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -22,7 +23,10 @@ import (
 // It defaults to "dev" when built without the flag (e.g. go run).
 var version = "dev"
 
-var scheme = runtime.NewScheme()
+var (
+	scheme            = runtime.NewScheme()
+	syncPeriodDefault = 5 * time.Minute
+)
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -36,11 +40,13 @@ func main() {
 	var metricsAddr string
 	var probeAddr string
 	var enableLeaderElection bool
+	var syncPeriod time.Duration
 
 	flag.StringVar(&chartPath, "chart-path", "/charts/batch-gateway", "Path to the batch-gateway Helm chart directory")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Address the metrics endpoint binds to")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Address the health probe endpoint binds to")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager")
+	flag.DurationVar(&syncPeriod, "sync-period", syncPeriodDefault, "How often to re-sync all LLMBatchGateway resources to catch out-of-band drift")
 
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -68,7 +74,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := controller.NewLLMBatchGatewayReconciler(mgr.GetClient(), mgr.GetScheme(), helmRenderer, mgr.GetEventRecorderFor("llmbatchgateway-controller")).SetupWithManager(mgr); err != nil {
+	if err := controller.NewLLMBatchGatewayReconciler(mgr.GetClient(), mgr.GetScheme(), helmRenderer, mgr.GetEventRecorderFor("llmbatchgateway-controller"), syncPeriod).SetupWithManager(mgr); err != nil {
 		logger.Error(err, "unable to create controller", "controller", "LLMBatchGateway")
 		os.Exit(1)
 	}

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -73,15 +74,17 @@ type LLMBatchGatewayReconciler struct {
 	Scheme       *runtime.Scheme
 	HelmRenderer *HelmRenderer
 	Recorder     record.EventRecorder
+	SyncPeriod   time.Duration
 	secretFilter *secretWatchFilter
 }
 
-func NewLLMBatchGatewayReconciler(c client.Client, scheme *runtime.Scheme, helm *HelmRenderer, recorder record.EventRecorder) *LLMBatchGatewayReconciler {
+func NewLLMBatchGatewayReconciler(c client.Client, scheme *runtime.Scheme, helm *HelmRenderer, recorder record.EventRecorder, syncPeriod time.Duration) *LLMBatchGatewayReconciler {
 	return &LLMBatchGatewayReconciler{
 		Client:       c,
 		Scheme:       scheme,
 		HelmRenderer: helm,
 		Recorder:     recorder,
+		SyncPeriod:   syncPeriod,
 		secretFilter: &secretWatchFilter{watched: make(map[string]struct{})},
 	}
 }
@@ -195,7 +198,7 @@ func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("updating status: %w", err)
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: r.SyncPeriod}, nil
 }
 
 func (r *LLMBatchGatewayReconciler) deleteOrphanedResources(

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -62,7 +63,25 @@ func TestReconcile(t *testing.T) {
 	}
 
 	fakeRecorder := record.NewFakeRecorder(100)
-	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer, fakeRecorder)
+	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer, fakeRecorder, 5*time.Minute)
+
+	t.Run("returns RequeueAfter on successful reconcile", func(t *testing.T) {
+		gw := newTestGateway("test-requeue")
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, gw) })
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace},
+		})
+		if err != nil {
+			t.Fatalf("Reconcile() error: %v", err)
+		}
+		if result.RequeueAfter != 5*time.Minute {
+			t.Errorf("RequeueAfter = %v, want %v", result.RequeueAfter, 5*time.Minute)
+		}
+	})
 
 	t.Run("creates all child resources", func(t *testing.T) {
 		gw := newTestGateway("test-create")


### PR DESCRIPTION
## Summary

Closes #22

- Return `ctrl.Result{RequeueAfter: r.SyncPeriod}` on every successful reconcile to catch out-of-band drift on child resources
- Interval configurable via `--sync-period` flag (default: `5m`)