### PR TITLE
feat(controller): add --reconcile-timeout to bound reconcile duration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,8 +24,9 @@ import (
 var version = "dev"
 
 var (
-	scheme            = runtime.NewScheme()
-	syncPeriodDefault = 5 * time.Minute
+	scheme                  = runtime.NewScheme()
+	syncPeriodDefault       = 5 * time.Minute
+	reconcileTimeoutDefault = 30 * time.Second
 )
 
 func init() {
@@ -41,12 +42,14 @@ func main() {
 	var probeAddr string
 	var enableLeaderElection bool
 	var syncPeriod time.Duration
+	var reconcileTimeout time.Duration
 
 	flag.StringVar(&chartPath, "chart-path", "/charts/batch-gateway", "Path to the batch-gateway Helm chart directory")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "Address the metrics endpoint binds to")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Address the health probe endpoint binds to")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager")
 	flag.DurationVar(&syncPeriod, "sync-period", syncPeriodDefault, "How often to re-sync all LLMBatchGateway resources to catch out-of-band drift")
+	flag.DurationVar(&reconcileTimeout, "reconcile-timeout", reconcileTimeoutDefault, "Maximum duration for a single reconcile")
 
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -74,7 +77,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := controller.NewLLMBatchGatewayReconciler(mgr.GetClient(), mgr.GetScheme(), helmRenderer, mgr.GetEventRecorderFor("llmbatchgateway-controller"), syncPeriod).SetupWithManager(mgr); err != nil { //nolint:staticcheck
+	if err := controller.NewLLMBatchGatewayReconciler(mgr.GetClient(), mgr.GetScheme(), helmRenderer, mgr.GetEventRecorderFor("llmbatchgateway-controller"), syncPeriod, reconcileTimeout).SetupWithManager(mgr); err != nil { //nolint:staticcheck
 		logger.Error(err, "unable to create controller", "controller", "LLMBatchGateway")
 		os.Exit(1)
 	}

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -79,25 +79,30 @@ type resourceKey struct {
 
 type LLMBatchGatewayReconciler struct {
 	client.Client
-	Scheme       *runtime.Scheme
-	HelmRenderer *HelmRenderer
-	Recorder     record.EventRecorder
-	SyncPeriod   time.Duration
-	secretFilter *secretWatchFilter
+	Scheme           *runtime.Scheme
+	HelmRenderer     *HelmRenderer
+	Recorder         record.EventRecorder
+	ReconcileTimeout time.Duration
+	SyncPeriod       time.Duration
+	secretFilter     *secretWatchFilter
 }
 
-func NewLLMBatchGatewayReconciler(c client.Client, scheme *runtime.Scheme, helm *HelmRenderer, recorder record.EventRecorder, syncPeriod time.Duration) *LLMBatchGatewayReconciler {
+func NewLLMBatchGatewayReconciler(c client.Client, scheme *runtime.Scheme, helm *HelmRenderer, recorder record.EventRecorder, syncPeriod time.Duration, reconcileTimeout time.Duration) *LLMBatchGatewayReconciler {
 	return &LLMBatchGatewayReconciler{
-		Client:       c,
-		Scheme:       scheme,
-		HelmRenderer: helm,
-		Recorder:     recorder,
-		SyncPeriod:   syncPeriod,
-		secretFilter: &secretWatchFilter{watched: make(map[string]struct{})},
+		Client:           c,
+		Scheme:           scheme,
+		HelmRenderer:     helm,
+		Recorder:         recorder,
+		ReconcileTimeout: reconcileTimeout,
+		SyncPeriod:       syncPeriod,
+		secretFilter:     &secretWatchFilter{watched: make(map[string]struct{})},
 	}
 }
 
 func (r *LLMBatchGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.ReconcileTimeout)
+	defer cancel()
+
 	logger := log.FromContext(ctx)
 
 	var gw batchv1alpha1.LLMBatchGateway

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -63,7 +64,10 @@ func TestReconcile(t *testing.T) {
 	}
 
 	fakeRecorder := record.NewFakeRecorder(100)
-	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer, fakeRecorder, 5*time.Minute)
+	resyncTimeout := 5 * time.Minute
+	reconcileTimeout := 30 * time.Second
+
+	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer, fakeRecorder, resyncTimeout, reconcileTimeout)
 
 	t.Run("returns RequeueAfter on successful reconcile", func(t *testing.T) {
 		gw := newTestGateway("test-requeue")
@@ -78,8 +82,8 @@ func TestReconcile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Reconcile() error: %v", err)
 		}
-		if result.RequeueAfter != 5*time.Minute {
-			t.Errorf("RequeueAfter = %v, want %v", result.RequeueAfter, 5*time.Minute)
+		if result.RequeueAfter != resyncTimeout {
+			t.Errorf("RequeueAfter = %v, want %v", result.RequeueAfter, resyncTimeout)
 		}
 	})
 
@@ -637,6 +641,37 @@ func isOwnedByUID(refs []metav1.OwnerReference, uid types.UID) bool {
 		}
 	}
 	return false
+}
+
+func TestReconcileTimeout(t *testing.T) {
+	ctx := context.Background()
+
+	helmRenderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway")
+	if err != nil {
+		t.Fatalf("NewHelmRenderer() error: %v", err)
+	}
+
+	fakeRecorder := record.NewFakeRecorder(100)
+	resyncTimeout := 5 * time.Minute
+	reconcileTimeout := -1 * time.Second
+	// Use a 1ns timeout so the context is expired before the first API call.
+	reconciler := NewLLMBatchGatewayReconciler(k8sClient, k8sClient.Scheme(), helmRenderer, fakeRecorder, resyncTimeout, reconcileTimeout)
+
+	gw := newTestGateway("test-timeout")
+	if err := k8sClient.Create(ctx, gw); err != nil {
+		t.Fatalf("creating CR: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, gw) })
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace},
+	})
+	if err == nil {
+		t.Fatal("Reconcile() expected error due to timeout, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Reconcile() error = %v, want context.DeadlineExceeded", err)
+	}
 }
 
 // assertEvent drains the fake recorder channel and asserts that at least one


### PR DESCRIPTION
## Summary

Closes #23

- Wraps the reconcile context with `context.WithTimeout` at the top of `Reconcile` to prevent hung API calls from blocking a worker indefinitely
- Configurable via `--reconcile-timeout` flag (default: `30s`)
- Test verifies timeout enforcement by passing a negative duration (guarantees context is already expired) and asserting `context.DeadlineExceeded`