### PR TITLE
feat: support integration with ODH operator

### DIFF
--- a/.github/workflows/verify-kustomize.yml
+++ b/.github/workflows/verify-kustomize.yml
@@ -1,0 +1,31 @@
+name: Verify Manifest Builds
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'config/**'
+      - 'Makefile'
+
+jobs:
+  verify-builds:
+    name: Verify kustomize builds
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Verify manifests
+        run: make verify-manifests

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,0 +1,26 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG CGO_ENABLED=1
+
+WORKDIR /opt/app-root/src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY api/ api/
+COPY internal/ internal/
+
+RUN mkdir -p bin && \
+    CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    GOEXPERIMENT=strictfipsruntime \
+    go build -a -o bin/manager ./cmd/
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:d91be7cea9f03a757d69ad7fcdfcd7849dba820110e7980d5e2a1f46ed06ea3b
+WORKDIR /
+COPY --from=builder /opt/app-root/src/bin/manager /manager
+COPY batch-gateway/charts/batch-gateway/ /charts/batch-gateway/
+
+USER 1001:1001
+ENTRYPOINT ["/manager"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,21 @@ install: manifests
 uninstall:
 	kubectl delete -f config/crd/bases/
 
+## Kustomize
+
+KUSTOMIZE_VERSION ?= v5.8.1
+KUSTOMIZE ?= $(shell pwd)/bin/kustomize
+
+.PHONY: kustomize
+kustomize: ## Install kustomize locally
+	@test -s $(KUSTOMIZE) || \
+		GOBIN=$(shell pwd)/bin go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
+
+.PHONY: verify-manifests
+verify-manifests: kustomize ## Verify that all manifest builds succeed
+	@echo "Running manifest verification script..."
+	@bash test/scripts/verify-manifests.sh
+
 ## Deploy (kustomize)
 
 .PHONY: deploy

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../crd
+  - ../rbac
+  - ../manager
+  - metrics_service.yaml
+
+patches:
+  - path: manager_metrics_patch.yaml
+    target:
+      kind: Deployment
+
+configMapGenerator:
+  - name: operator-params
+    envs:
+      - params.env
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: operator-params
+      fieldPath: data.BATCH_GATEWAY_OPERATOR_IMAGE
+    targets:
+      - select:
+          kind: Deployment
+          name: batch-gw-operator-controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image

--- a/config/base/manager_metrics_patch.yaml
+++ b/config/base/manager_metrics_patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8443

--- a/config/base/metrics_service.yaml
+++ b/config/base/metrics_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: batch-gw-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: batch-gw-operator

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,0 +1,1 @@
+BATCH_GATEWAY_OPERATOR_IMAGE=quay.io/opendatahub/odh-batch-gateway-operator:odh-stable

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,0 +1,4 @@
+releases:
+  - name: LLM-D Batch Gateway Operator
+    version: v0.1.0
+    repoUrl: https://github.com/opendatahub-io/llm-d-batch-gateway-operator

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub
+
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: opendatahub
+    includeSelectors: false

--- a/config/overlays/rhoai/kustomization.yaml
+++ b/config/overlays/rhoai/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: redhat-ods-applications
+
+resources:
+  - ../../base
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: rhods
+    includeSelectors: false

--- a/test/scripts/verify-manifests.sh
+++ b/test/scripts/verify-manifests.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# This script verifies that all manifest builds succeed
+# Prerequisites:
+#   - kustomize must be installed (run 'make kustomize' first)
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo "========================================"
+echo "Manifest Build Verification"
+echo "========================================"
+echo ""
+
+# Check prerequisites
+echo "Checking prerequisites..."
+
+if [ ! -f "bin/kustomize" ]; then
+    echo -e "${RED}ERROR: kustomize not found at bin/kustomize${NC}"
+    echo "Run 'make kustomize' to install it"
+    exit 1
+fi
+echo -e "${GREEN}✅ kustomize found${NC}"
+echo ""
+
+# Track overall status
+OVERALL_EXIT_CODE=0
+
+# ==========================================
+# Step 1: Verify config/base builds
+# ==========================================
+echo "Step 1: Verifying config/base"
+echo "----------------------------------------------"
+
+echo "Building config/base..."
+if bin/kustomize build config/base > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ config/base builds successfully${NC}"
+else
+    echo -e "${RED}✗ config/base failed to build${NC}"
+    bin/kustomize build config/base || true
+    OVERALL_EXIT_CODE=1
+fi
+echo ""
+
+# ==========================================
+# Step 2: Verify kustomize overlays build
+# ==========================================
+echo "Step 2: Verifying kustomize overlays"
+echo "----------------------------------------------"
+
+OVERLAY_EXIT_CODE=0
+VALIDATED_OVERLAYS=()
+
+for overlay in config/overlays/*/; do
+    if [ ! -f "${overlay}kustomization.yaml" ]; then
+        continue
+    fi
+
+    overlay_name=$(basename "$overlay")
+    echo "Building overlay: $overlay_name"
+    if bin/kustomize build "$overlay" > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ $overlay_name builds successfully${NC}"
+        VALIDATED_OVERLAYS+=("$overlay_name")
+    else
+        echo -e "${RED}✗ $overlay_name failed to build${NC}"
+        bin/kustomize build "$overlay" || true
+        OVERLAY_EXIT_CODE=1
+    fi
+done
+
+if [ "$OVERLAY_EXIT_CODE" -ne 0 ]; then
+    echo ""
+    echo -e "${RED}ERROR: One or more kustomize overlays failed to build${NC}"
+    echo "Please fix the kustomization.yaml files and try again."
+    OVERALL_EXIT_CODE=1
+else
+    echo ""
+    echo -e "${GREEN}✅ All kustomize overlays build successfully${NC}"
+fi
+echo ""
+
+# ==========================================
+# Summary
+# ==========================================
+echo "========================================"
+echo "Build Verification Summary"
+echo "========================================"
+echo ""
+
+if [ "${#VALIDATED_OVERLAYS[@]}" -gt 0 ]; then
+    echo -e "${BLUE}Kustomize Overlays:${NC}"
+    for overlay in config/overlays/*/; do
+        if [ ! -f "${overlay}kustomization.yaml" ]; then
+            continue
+        fi
+        overlay_name=$(basename "$overlay")
+        if printf '%s\n' "${VALIDATED_OVERLAYS[@]}" | grep -qx -- "$overlay_name"; then
+            echo -e "  ${GREEN}✓${NC} $overlay_name"
+        else
+            echo -e "  ${RED}✗${NC} $overlay_name"
+        fi
+    done
+    echo ""
+fi
+
+if [ "$OVERALL_EXIT_CODE" -eq 0 ]; then
+    echo "========================================"
+    echo -e "${GREEN}✅ All manifests validated successfully!${NC}"
+    echo "========================================"
+else
+    echo "========================================"
+    echo -e "${RED}❌ Some manifests failed validation${NC}"
+    echo "========================================"
+    exit 1
+fi


### PR DESCRIPTION
## Description
Add kustomize manifests and CI for ODH/RHOAI operator integration.

- `config/base/`: base kustomization with params.env image replacement
- `config/overlays/odh/` and `config/overlays/rhoai/`: platform-specific overlays
- `config/component_metadata.yaml`: release metadata for ODH operator
- `LICENSE`: Apache License 2.0
- CI workflow + `make verify-manifests` to validate kustomize builds

Ref: [RHOAIENG-63964](https://redhat.atlassian.net/browse/RHOAIENG-63964)
ODH operator PR: https://github.com/opendatahub-io/opendatahub-operator/pull/3579

## How Has This Been Tested?
- `make verify-manifests`: all overlays build successfully
- `kustomize build` verified locally for both odh and rhoai overlays

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow to verify manifest builds on pushes and PRs
  * Added Makefile targets to install kustomize and run manifest verification
  * Added manifest validation script for base and overlay configurations
  * Added Apache License 2.0

* **Documentation**
  * Added component metadata specifying Batch Gateway Operator v0.1.0
  * Added Kustomize base and overlays for deployment variants (OpenDataHub, RHOAI)
  * Exposed controller metrics endpoint and added a metrics Service and image parameter configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->