### PR TITLE
fix: unify resource names and remove namePrefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 
 .PHONY: manifests
 manifests:
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=batch-gateway-operator crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate:

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -25,6 +25,6 @@ replacements:
     targets:
       - select:
           kind: Deployment
-          name: batch-gateway-operator-controller-manager
+          name: batch-gateway-operator
         fieldPaths:
           - spec.template.spec.containers.[name=manager].image

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -3,8 +3,6 @@ kind: Kustomization
 
 namespace: batch-gateway-operator-system
 
-namePrefix: batch-gateway-operator-
-
 resources:
 - ../crd
 - ../rbac

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: batch-gateway-operator-controller-manager
+  name: batch-gateway-operator
   namespace: system
   labels:
     control-plane: controller-manager
@@ -57,7 +57,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-      serviceAccountName: batch-gateway-operator-controller-manager
+      serviceAccountName: batch-gateway-operator
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: batch-gateway-operator-controller-manager
+  name: batch-gateway-operator
   namespace: system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: batch-gateway-operator
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,15 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: batch-gateway-operator-manager-rolebinding
+  name: batch-gateway-operator
   labels:
     app.kubernetes.io/name: batch-gateway-operator
     app.kubernetes.io/managed-by: kustomize
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: batch-gateway-operator-manager-role
+  name: batch-gateway-operator
 subjects:
 - kind: ServiceAccount
-  name: batch-gateway-operator-controller-manager
-  namespace: system
+  name: batch-gateway-operator

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: batch-gateway-operator-controller-manager
+  name: batch-gateway-operator
   namespace: system
   labels:
     app.kubernetes.io/name: batch-gateway-operator

--- a/hack/dev-deploy.sh
+++ b/hack/dev-deploy.sh
@@ -419,21 +419,26 @@ wait_for_batch_gateway() {
 
 print_status() {
     step "Deployment complete!"
-    echo ""
-    echo "  Operator:"
-    kubectl get pods -n batch-gateway-operator-system
-    echo ""
-    echo "  Batch Gateway:"
-    kubectl get pods -n "${NAMESPACE}" -l "app.kubernetes.io/instance=batch-gateway"
-    echo ""
+
+    echo "----------------------------------------"
+    echo "  Operator (batch-gateway-operator-system):"
+    kubectl get all -n batch-gateway-operator-system
+
+    echo "----------------------------------------"
     echo "  CR Status:"
-    kubectl get llmbatchgateway -n "${NAMESPACE}" 2>/dev/null || true
-    echo ""
+    kubectl get llmbatchgateway -n "${NAMESPACE}"
+
+    echo "----------------------------------------"
+    echo "  Workloads (${NAMESPACE}):"
+    kubectl get all -n "${NAMESPACE}"
+
+    echo "----------------------------------------"
     echo "  Access:"
     echo "    API Server:  http://localhost:${LOCAL_PORT}"
     echo "    Observability: http://localhost:${LOCAL_OBS_PORT}"
     echo "    Processor:   http://localhost:${LOCAL_PROCESSOR_PORT}"
-    echo ""
+
+    echo "----------------------------------------"
     echo "  Cleanup:"
     echo "    make dev-clean        # remove operator + deps"
     echo "    make dev-rm-cluster   # delete Kind cluster"


### PR DESCRIPTION
## Description

Align kustomize resource naming with the [kuberay convention](https://github.com/opendatahub-io/kuberay/tree/master/ray-operator/config/rbac): use a single consistent name `batch-gateway-operator` for ClusterRole, ClusterRoleBinding, ServiceAccount, and Deployment instead of relying on `namePrefix` in `config/default/`.

**Before:** Some resources used bare names (`manager-role`, `leader-election-role`) while others had the `batch-gateway-operator-` prefix . The `config/default/` overlay applied `namePrefix: batch-gateway-operator-` to unify them at render time. This caused a name mismatch when rendering from `config/base/` (used by downstream consumers like ai-gateway-operator), where `role.yaml` had `manager-role` but `role_binding.yaml` referenced `batch-gateway-operator-manager-role`.

**After:** All resources use `batch-gateway-operator` as their name. `namePrefix` is removed from `config/default/`. Names are consistent regardless of which overlay is used.

## How Has This Been Tested?

Verified `kustomize build` on all overlays:
- `config/default/` — no double-prefixed names, all references consistent
- `config/base/` — ClusterRole, ClusterRoleBinding, ServiceAccount names match
- `config/overlays/odh/` — correct names with `namespace: opendatahub`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator naming configuration across deployment and Kubernetes role-based access control (RBAC) settings for simplified and standardized infrastructure setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->