### PR TITLE
feat: add aggregated ClusterRoles for LLMBatchGateway CRD

### DIFF
--- a/config/rbac/aggregate_roles.yaml
+++ b/config/rbac/aggregate_roles.yaml
@@ -1,0 +1,32 @@
+# Aggregated into the built-in "admin" and "edit" ClusterRoles so that
+# namespace admins/editors can manage LLMBatchGateway CRs without extra
+# RoleBindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llmbatchgateway-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups: ["batch.llm-d.ai"]
+  resources: ["llmbatchgateways"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+- apiGroups: ["batch.llm-d.ai"]
+  resources: ["llmbatchgateways/status"]
+  verbs: ["get"]
+---
+# Aggregated into the built-in "view" ClusterRole for read-only access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llmbatchgateway-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups: ["batch.llm-d.ai"]
+  resources: ["llmbatchgateways"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["batch.llm-d.ai"]
+  resources: ["llmbatchgateways/status"]
+  verbs: ["get"]

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- aggregate_roles.yaml


### PR DESCRIPTION
## Summary

Add aggregated ClusterRoles that automatically merge into the built-in `admin`, `edit`, and `view` ClusterRoles via the `rbac.authorization.k8s.io/aggregate-to-*` labels. This allows namespace admins and editors to manage `LLMBatchGateway` custom resources without requiring manual RoleBindings for the `batch.llm-d.ai` API group.

### Changes

- **`config/rbac/aggregate_roles.yaml`**: Two new ClusterRoles:
  - `llmbatchgateway-admin`: aggregated into `admin` and `edit`, grants full CRUD on `llmbatchgateways`
  - `llmbatchgateway-view`: aggregated into `view`, grants read-only access
- **`config/rbac/kustomization.yaml`**: Include the new file in kustomize build

### Testing

Tested end-to-end on OpenShift 4.21 (HyperShift/AWS):

1. Deployed operator as cluster-admin (CRDs, ClusterRoles, operator Deployment)
2. Created a regular `testuser` with only the built-in `admin` role on a namespace
3. As `testuser` (no manual CRD RoleBindings):
   - Deployed PostgreSQL, Redis, MinIO, vLLM simulator
   - Created `LLMBatchGateway` CR — succeeded via aggregated role
   - Ran full batch API test (upload file → create batch → poll → retrieve output) — completed successfully
4. All components run under `restricted-v2` SCC with no custom SCC required

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New admin cluster role enabling full management of batch gateway resources with complete access permissions.
  * New view cluster role providing read-only access to batch gateway resources and their status.

* **Chores**
  * Updated role-based access control configuration for batch gateway resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->