### PR TITLE
fix: bump go.mod to 1.26 and clean up NodePort services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/llm-d-batch-gateway-operator
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2

--- a/hack/dev-clean.sh
+++ b/hack/dev-clean.sh
@@ -33,6 +33,9 @@ kubectl delete deployment,svc minio -n "${NAMESPACE}" --ignore-not-found
 step "Removing vLLM simulator..."
 kubectl delete deployment,svc vllm-sim -n "${NAMESPACE}" --ignore-not-found
 
+step "Removing NodePort services..."
+kubectl delete svc batch-gateway-apiserver-nodeport batch-gateway-processor-nodeport -n "${NAMESPACE}" --ignore-not-found
+
 step "Removing secrets..."
 kubectl delete secret batch-gateway-secrets -n "${NAMESPACE}" --ignore-not-found
 


### PR DESCRIPTION
## Summary

Address the two remaining items from #10:

### Item 3: Dockerfile Go version vs go.mod
Bump `go.mod` directive from `1.25.0` to `1.26.0` to match the Dockerfile builder stage (`golang:1.26`).

### Item 4: dev-clean.sh does not remove NodePort services
Add cleanup of `batch-gateway-apiserver-nodeport` and `batch-gateway-processor-nodeport` services in `hack/dev-clean.sh`. These are created by `hack/dev-deploy.sh` but were not being deleted during cleanup.

Items 1, 2, and 5 from the issue were already addressed in previous PRs.

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go toolchain requirement to version 1.26.0
  * Enhanced development cleanup script to remove batch gateway NodePort services during environment teardown

<!-- end of auto-generated comment: release notes by coderabbit.ai -->