### PR TITLE
fix: revert go.mod to 1.25 to match Konflux builder image

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/llm-d-batch-gateway-operator
 
-go 1.26.0
+go 1.25.0
 
 require (
 	github.com/cert-manager/cert-manager v1.20.2


### PR DESCRIPTION
## Description

Revert `go.mod` from 1.26 to 1.25 to match `Dockerfile.konflux` builder image (`go-toolset:1.25.8`). The Go 1.26 bump in #10 broke Konflux builds.

Fixes the build failure reported in [RHOAIENG-64691](https://redhat.atlassian.net/browse/RHOAIENG-64691?focusedCommentId=17183168).

## How Has This Been Tested?

- `go build ./...` passes locally with Go 1.25