### PR TITLE
feat: add ODH monitoring scrape label to ServiceMonitor and PodMonitor

### DIFF
--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -19,6 +19,11 @@ import (
 	batchv1alpha1 "github.com/opendatahub-io/llm-d-batch-gateway-operator/api/v1alpha1"
 )
 
+const (
+	odhMonitoringScrapeLabel = "monitoring.opendatahub.io/scrape"
+	odhMonitoringScrapeValue = "true"
+)
+
 type HelmRenderer struct {
 	chart *chart.Chart
 }
@@ -210,6 +215,9 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[
 	if gw.Spec.Monitoring != nil && gw.Spec.Monitoring.Enabled {
 		apiserver["serviceMonitor"] = map[string]interface{}{
 			"enabled": true,
+			"labels": map[string]interface{}{
+				odhMonitoringScrapeLabel: odhMonitoringScrapeValue,
+			},
 		}
 	}
 
@@ -256,6 +264,9 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[
 	if gw.Spec.Monitoring != nil && gw.Spec.Monitoring.Enabled {
 		processor["podMonitor"] = map[string]interface{}{
 			"enabled": true,
+			"labels": map[string]interface{}{
+				odhMonitoringScrapeLabel: odhMonitoringScrapeValue,
+			},
 		}
 	}
 
@@ -290,6 +301,16 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[
 	}
 	if len(gcConfig) > 0 {
 		gc["config"] = gcConfig
+	}
+
+	// PodMonitor
+	if gw.Spec.Monitoring != nil && gw.Spec.Monitoring.Enabled {
+		gc["podMonitor"] = map[string]interface{}{
+			"enabled": true,
+			"labels": map[string]interface{}{
+				odhMonitoringScrapeLabel: odhMonitoringScrapeValue,
+			},
+		}
 	}
 
 	vals["gc"] = gc

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -219,13 +219,33 @@ func TestSpecToHelmValues_Monitoring(t *testing.T) {
 		if got := sm["enabled"]; got != true {
 			t.Errorf("serviceMonitor.enabled = %v, want true", got)
 		}
+		labels := sm["labels"].(map[string]interface{})
+		if got := labels[odhMonitoringScrapeLabel]; got != odhMonitoringScrapeValue {
+			t.Errorf("serviceMonitor scrape label = %v, want \"true\"", got)
+		}
 	})
 
-	t.Run("pod monitor enabled", func(t *testing.T) {
+	t.Run("processor pod monitor enabled with scrape label", func(t *testing.T) {
 		processor := vals["processor"].(map[string]interface{})
 		pm := processor["podMonitor"].(map[string]interface{})
 		if got := pm["enabled"]; got != true {
 			t.Errorf("podMonitor.enabled = %v, want true", got)
+		}
+		labels := pm["labels"].(map[string]interface{})
+		if got := labels[odhMonitoringScrapeLabel]; got != odhMonitoringScrapeValue {
+			t.Errorf("podMonitor scrape label = %v, want \"true\"", got)
+		}
+	})
+
+	t.Run("gc pod monitor enabled with scrape label", func(t *testing.T) {
+		gc := vals["gc"].(map[string]interface{})
+		pm := gc["podMonitor"].(map[string]interface{})
+		if got := pm["enabled"]; got != true {
+			t.Errorf("podMonitor.enabled = %v, want true", got)
+		}
+		labels := pm["labels"].(map[string]interface{})
+		if got := labels[odhMonitoringScrapeLabel]; got != odhMonitoringScrapeValue {
+			t.Errorf("podMonitor scrape label = %v, want \"true\"", got)
 		}
 	})
 }
@@ -391,9 +411,9 @@ func TestRenderChart_WithMonitoring(t *testing.T) {
 		}
 	})
 
-	t.Run("renders pod monitor", func(t *testing.T) {
-		if got := kinds["PodMonitor"]; got != 1 {
-			t.Errorf("PodMonitor count = %d, want 1", got)
+	t.Run("renders pod monitors", func(t *testing.T) {
+		if got := kinds["PodMonitor"]; got != 2 {
+			t.Errorf("PodMonitor count = %d, want 2 (processor + gc)", got)
 		}
 	})
 }


### PR DESCRIPTION
## Description

Add `monitoring.opendatahub.io/scrape: "true"` label to ServiceMonitor and PodMonitor when monitoring is enabled. This allows the ODH observability stack to discover and scrape batch-gateway metrics.

Ref: [RHOAIENG-63967](https://redhat.atlassian.net/browse/RHOAIENG-63967), [ODH ADR-0010](https://github.com/opendatahub-io/architecture-decision-records/blob/main/architecture-decision-records/operator/ODH-ADR-Operator-0010-Observability-component%20metrics%20scraping.md)

## How Has This Been Tested?

- `make test` — all unit tests pass, including updated `TestSpecToHelmValues_Monitoring` verifying the scrape label on both ServiceMonitor and PodMonitor

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring scrape labels to service monitors and pod monitors when monitoring is enabled. This improvement enhances system observability by ensuring proper identification and traceability of monitoring data, enabling more effective monitoring and alerting across your infrastructure.

* **Tests**
  * Monitoring tests updated to validate scrape label configuration on service and pod monitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->