### PR TITLE
feat: get api, process and gc image from params.env

### DIFF
--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -179,11 +179,6 @@ type APIServerSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// Image is the container image for the API server (e.g. "ghcr.io/org/apiserver:v1.2.3").
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=1024
-	Image string `json:"image"`
-
 	// Resources defines CPU and memory requests/limits for the API server container.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
@@ -262,11 +257,6 @@ type ProcessorSpec struct {
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
-
-	// Image is the container image for the processor (e.g. "ghcr.io/org/processor:v1.2.3").
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=1024
-	Image string `json:"image"`
 
 	// Resources defines CPU and memory requests/limits for the processor container.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
@@ -359,11 +349,6 @@ type ProcessorConfigSpec struct {
 
 // GCSpec configures the garbage-collector component.
 type GCSpec struct {
-	// Image is the container image for the GC (e.g. "ghcr.io/org/batch-gc:v1.2.3").
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=1024
-	Image string `json:"image"`
-
 	// Interval is how often the GC runs (e.g. "30m").
 	// +kubebuilder:default="30m"
 	// +kubebuilder:validation:Pattern=`^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +28,41 @@ import (
 // version is stamped at build time via -ldflags "-X main.version=<version>".
 // It defaults to "dev" when built without the flag (e.g. go run).
 var version = "dev"
+
+// the way for batch-gateway-operator to know which exactly are the 3 images are via env variable set in the deployment
+// since it cannot read params.env which is updated by opendatahub-operator
+const (
+	envImageAPIServer = "LLM_D_BATCH_GATEWAY_APISERVER_IMAGE"
+	envImageProcessor = "LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE"
+	envImageGC        = "LLM_D_BATCH_GATEWAY_GC_IMAGE"
+)
+
+// componentImagesFromEnv reads the pinned component images from the environment
+// and fails if any are missing, since the operator cannot render workloads
+// without them.
+func componentImagesFromEnv() (controller.ComponentImages, error) {
+	images := controller.ComponentImages{
+		APIServer: os.Getenv(envImageAPIServer),
+		Processor: os.Getenv(envImageProcessor),
+		GC:        os.Getenv(envImageGC),
+	}
+
+	var missing []string
+	if images.APIServer == "" {
+		missing = append(missing, envImageAPIServer)
+	}
+	if images.Processor == "" {
+		missing = append(missing, envImageProcessor)
+	}
+	if images.GC == "" {
+		missing = append(missing, envImageGC)
+	}
+	if len(missing) > 0 {
+		return controller.ComponentImages{}, fmt.Errorf("required image environment variables are not set: %s", strings.Join(missing, ", "))
+	}
+
+	return images, nil
+}
 
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;create;update;patch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;prometheusrules,verbs=get;create;update;patch
@@ -79,7 +116,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	helmRenderer, err := controller.NewHelmRenderer(chartPath)
+	images, err := componentImagesFromEnv()
+	if err != nil {
+		logger.Error(err, "unable to resolve 3 component images from env variables")
+		os.Exit(1)
+	}
+
+	helmRenderer, err := controller.NewHelmRenderer(chartPath, images)
 	if err != nil {
 		logger.Error(err, "unable to create helm renderer", "chartPath", chartPath)
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,7 @@ import (
 // It defaults to "dev" when built without the flag (e.g. go run).
 var version = "dev"
 
-// the way for batch-gateway-operator to know which exactly are the 3 images are via env variable set in the deployment
+// the way for batch-gateway-operator to know which exactly are the 3 component images(disgest) are via env variable set in the deployment
 // since it cannot read params.env which is updated by opendatahub-operator
 const (
 	envImageAPIServer = "LLM_D_BATCH_GATEWAY_APISERVER_IMAGE"

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -21,10 +21,40 @@ replacements:
   - source:
       kind: ConfigMap
       name: operator-params
-      fieldPath: data.BATCH_GATEWAY_OPERATOR_IMAGE
+      fieldPath: data.LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE
     targets:
       - select:
           kind: Deployment
           name: batch-gateway-operator
         fieldPaths:
           - spec.template.spec.containers.[name=manager].image
+  - source:
+      kind: ConfigMap
+      name: operator-params
+      fieldPath: data.LLM_D_BATCH_GATEWAY_APISERVER_IMAGE
+    targets:
+      - select:
+          kind: Deployment
+          name: batch-gateway-operator
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=LLM_D_BATCH_GATEWAY_APISERVER_IMAGE].value
+  - source:
+      kind: ConfigMap
+      name: operator-params
+      fieldPath: data.LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE
+    targets:
+      - select:
+          kind: Deployment
+          name: batch-gateway-operator
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE].value
+  - source:
+      kind: ConfigMap
+      name: operator-params
+      fieldPath: data.LLM_D_BATCH_GATEWAY_GC_IMAGE
+    targets:
+      - select:
+          kind: Deployment
+          name: batch-gateway-operator
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=LLM_D_BATCH_GATEWAY_GC_IMAGE].value

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -13,14 +13,14 @@ patches:
       kind: Deployment
 
 configMapGenerator:
-  - name: operator-params
+  - name: batch-gateway-operator-params
     envs:
       - params.env
 
 replacements:
   - source:
       kind: ConfigMap
-      name: operator-params
+      name: batch-gateway-operator-params
       fieldPath: data.LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE
     targets:
       - select:
@@ -30,7 +30,7 @@ replacements:
           - spec.template.spec.containers.[name=manager].image
   - source:
       kind: ConfigMap
-      name: operator-params
+      name: batch-gateway-operator-params
       fieldPath: data.LLM_D_BATCH_GATEWAY_APISERVER_IMAGE
     targets:
       - select:
@@ -40,7 +40,7 @@ replacements:
           - spec.template.spec.containers.[name=manager].env.[name=LLM_D_BATCH_GATEWAY_APISERVER_IMAGE].value
   - source:
       kind: ConfigMap
-      name: operator-params
+      name: batch-gateway-operator-params
       fieldPath: data.LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE
     targets:
       - select:
@@ -50,7 +50,7 @@ replacements:
           - spec.template.spec.containers.[name=manager].env.[name=LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE].value
   - source:
       kind: ConfigMap
-      name: operator-params
+      name: batch-gateway-operator-params
       fieldPath: data.LLM_D_BATCH_GATEWAY_GC_IMAGE
     targets:
       - select:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,1 +1,4 @@
-BATCH_GATEWAY_OPERATOR_IMAGE=quay.io/opendatahub/odh-batch-gateway-operator:odh-stable
+LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE=quay.io/opendatahub/odh-batch-gateway-operator:odh-stable
+LLM_D_BATCH_GATEWAY_APISERVER_IMAGE=quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-stable
+LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE=quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
+LLM_D_BATCH_GATEWAY_GC_IMAGE=quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -146,11 +146,6 @@ spec:
                         format: int32
                         type: integer
                     type: object
-                  image:
-                    description: Image is the container image for the API server (e.g.
-                      "ghcr.io/org/apiserver:v1.2.3").
-                    maxLength: 1024
-                    type: string
                   replicas:
                     default: 1
                     description: |-
@@ -219,8 +214,6 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
-                required:
-                - image
                 type: object
               dbBackend:
                 default: postgresql
@@ -337,17 +330,11 @@ spec:
                         format: int32
                         type: integer
                     type: object
-                  image:
-                    description: Image is the container image for the GC (e.g. "ghcr.io/org/batch-gc:v1.2.3").
-                    maxLength: 1024
-                    type: string
                   interval:
                     default: 30m
                     description: Interval is how often the GC runs (e.g. "30m").
                     pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                     type: string
-                required:
-                - image
                 type: object
               grafana:
                 description: Grafana enables the bundled Grafana dashboard ConfigMap.
@@ -544,11 +531,6 @@ spec:
                     required:
                     - url
                     type: object
-                  image:
-                    description: Image is the container image for the processor (e.g.
-                      "ghcr.io/org/processor:v1.2.3").
-                    maxLength: 1024
-                    type: string
                   modelGateways:
                     additionalProperties:
                       description: InferenceGatewaySpec configures a connection to
@@ -676,8 +658,6 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
-                required:
-                - image
                 type: object
               prometheusRule:
                 description: PrometheusRule configures a PrometheusRule resource with

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,6 +30,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: LLM_D_BATCH_GATEWAY_APISERVER_IMAGE
+          value: quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-stable
+        - name: LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE
+          value: quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
+        - name: LLM_D_BATCH_GATEWAY_GC_IMAGE
+          value: quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable
         ports:
         - containerPort: 8443
           name: metrics

--- a/config/samples/batch_v1alpha1_llmbatchgateway.yaml
+++ b/config/samples/batch_v1alpha1_llmbatchgateway.yaml
@@ -16,17 +16,16 @@ spec:
     s3:
       region: us-east-1
       endpoint: https://s3.example.com
+  # Component images are NOT set here. They are pinned by the operator (sourced
+  # from params.env), so the platform controls which images run.
   apiServer:
     replicas: 1
-    image: ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest
   processor:
     replicas: 1
-    image: ghcr.io/llm-d-incubation/batch-gateway-processor:latest
     globalInferenceGateway:
       url: http://inference-gateway.default.svc:8000
       requestTimeout: 5m
   gc:
-    image: ghcr.io/llm-d-incubation/batch-gateway-gc:latest
     interval: 30m
 ---
 # ReferenceGrant required for cross-namespace secretRef.

--- a/config/samples/dev.yaml
+++ b/config/samples/dev.yaml
@@ -15,10 +15,8 @@ spec:
       autoCreateBucket: true
   apiServer:
     replicas: 1
-    image: ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest
   processor:
     replicas: 1
-    image: ghcr.io/llm-d-incubation/batch-gateway-processor:latest
     globalInferenceGateway:
       url: http://vllm-sim.default.svc.cluster.local:8000
       requestTimeout: 5m
@@ -26,5 +24,4 @@ spec:
       initialBackoff: 1s
       maxBackoff: 60s
   gc:
-    image: ghcr.io/llm-d-incubation/batch-gateway-gc:latest
     interval: 30m

--- a/hack/dev-deploy.sh
+++ b/hack/dev-deploy.sh
@@ -18,9 +18,12 @@ MINIO_REGION="${MINIO_REGION:-us-east-1}"
 GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-}"
 PROMETHEUS_OPERATOR_VERSION="${PROMETHEUS_OPERATOR_VERSION:-}"
 
-APISERVER_IMG="${APISERVER_IMG:-ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest}"
-PROCESSOR_IMG="${PROCESSOR_IMG:-ghcr.io/llm-d-incubation/batch-gateway-processor:latest}"
-GC_IMG="${GC_IMG:-ghcr.io/llm-d-incubation/batch-gateway-gc:latest}"
+# read from params.env if you wanna test a different image, go update params.env
+PARAMS_ENV="${OPERATOR_DIR}/config/base/params.env"
+param_image() { grep -E "^$1=" "${PARAMS_ENV}" 2>/dev/null | head -n1 | cut -d= -f2- || true; }
+APISERVER_IMG="${APISERVER_IMG:-$(param_image LLM_D_BATCH_GATEWAY_APISERVER_IMAGE)}"
+PROCESSOR_IMG="${PROCESSOR_IMG:-$(param_image LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE)}"
+GC_IMG="${GC_IMG:-$(param_image LLM_D_BATCH_GATEWAY_GC_IMAGE)}"
 VLLM_SIM_IMG="${VLLM_SIM_IMG:-ghcr.io/llm-d/llm-d-inference-sim:latest}"
 
 # Port configuration (matches batch-gateway defaults)
@@ -245,7 +248,13 @@ deploy_operator() {
     make install
     IMG="${OPERATOR_IMG}" make deploy
 
-    kubectl rollout status deployment -l control-plane=controller-manager \
+    step "Setting component images on the operator..."
+    kubectl set env deployment/batch-gateway-operator -n batch-gateway-operator-system \
+        LLM_D_BATCH_GATEWAY_APISERVER_IMAGE="${APISERVER_IMG}" \
+        LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE="${PROCESSOR_IMG}" \
+        LLM_D_BATCH_GATEWAY_GC_IMAGE="${GC_IMG}"
+
+    kubectl rollout status deployment/batch-gateway-operator \
         -n batch-gateway-operator-system --timeout=120s
 
     log "Operator deployed."

--- a/hack/dev-deploy.sh
+++ b/hack/dev-deploy.sh
@@ -8,6 +8,8 @@ OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-batch-gateway-dev}"
 NAMESPACE="${NAMESPACE:-default}"
+# Operator namespace, must match config/default/kustomization.yaml's `namespace:` field.
+OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-batch-gateway-operator-system}"
 OPERATOR_IMG="${OPERATOR_IMG:-localhost/batch-gateway-operator:dev}"
 
 POSTGRESQL_PASSWORD="${POSTGRESQL_PASSWORD:-postgres}"
@@ -244,18 +246,19 @@ deploy_operator() {
     step "Installing CRD and deploying operator..."
     cd "${OPERATOR_DIR}"
 
-    kubectl create namespace batch-gateway-operator-system 2>/dev/null || true
+    kubectl create namespace "${OPERATOR_NAMESPACE}" 2>/dev/null || true
     make install
     IMG="${OPERATOR_IMG}" make deploy
 
-    step "Setting component images on the operator..."
-    kubectl set env deployment/batch-gateway-operator -n batch-gateway-operator-system \
+    # override the env vars on the deployment to pin the images dev wants (defaults read from params.env.
+    step "Setting 3 component images on the operator deployment as env variable..."
+    kubectl set env deployment/batch-gateway-operator -n "${OPERATOR_NAMESPACE}" \
         LLM_D_BATCH_GATEWAY_APISERVER_IMAGE="${APISERVER_IMG}" \
         LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE="${PROCESSOR_IMG}" \
         LLM_D_BATCH_GATEWAY_GC_IMAGE="${GC_IMG}"
 
     kubectl rollout status deployment/batch-gateway-operator \
-        -n batch-gateway-operator-system --timeout=120s
+        -n "${OPERATOR_NAMESPACE}" --timeout=120s
 
     log "Operator deployed."
 }
@@ -349,8 +352,8 @@ print_status() {
     step "Deployment complete!"
 
     echo "----------------------------------------"
-    echo "  Operator (batch-gateway-operator-system):"
-    kubectl get all -n batch-gateway-operator-system
+    echo "  Operator (${OPERATOR_NAMESPACE}):"
+    kubectl get all -n "${OPERATOR_NAMESPACE}"
 
     echo "----------------------------------------"
     echo "  CR Status:"

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -24,20 +24,31 @@ const (
 	odhMonitoringScrapeValue = "true"
 )
 
-type HelmRenderer struct {
-	chart *chart.Chart
+// ComponentImages holds the container images for the batch-gateway components.
+// These are supplied to the operator via environment variables (sourced from
+// params.env) rather than the LLMBatchGateway CR, so that the platform — not
+// the user creating the CR — controls which images are deployed.
+type ComponentImages struct {
+	APIServer string
+	Processor string
+	GC        string
 }
 
-func NewHelmRenderer(chartPath string) (*HelmRenderer, error) {
+type HelmRenderer struct {
+	chart  *chart.Chart
+	images ComponentImages
+}
+
+func NewHelmRenderer(chartPath string, images ComponentImages) (*HelmRenderer, error) {
 	c, err := loader.Load(chartPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading chart from %s: %w", chartPath, err)
 	}
-	return &HelmRenderer{chart: c}, nil
+	return &HelmRenderer{chart: c, images: images}, nil
 }
 
 func (h *HelmRenderer) RenderChart(gw *batchv1alpha1.LLMBatchGateway, secretName string) ([]*unstructured.Unstructured, error) {
-	vals := specToHelmValues(gw, secretName)
+	vals := specToHelmValues(gw, secretName, h.images)
 
 	releaseOpts := chartutil.ReleaseOptions{
 		Name:      gw.Name,
@@ -80,7 +91,7 @@ func (h *HelmRenderer) RenderChart(gw *batchv1alpha1.LLMBatchGateway, secretName
 	return objects, nil
 }
 
-func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[string]interface{} {
+func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string, images ComponentImages) map[string]interface{} {
 	vals := map[string]interface{}{}
 
 	// --- Global ---
@@ -145,7 +156,7 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[
 	vals["global"] = global
 
 	// --- API Server ---
-	apiRepo, apiTag := splitImage(gw.Spec.APIServer.Image)
+	apiRepo, apiTag := splitImage(images.APIServer)
 	apiserver := map[string]interface{}{
 		"enabled": true,
 		"image": map[string]interface{}{
@@ -224,7 +235,7 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[
 	vals["apiserver"] = apiserver
 
 	// --- Processor ---
-	procRepo, procTag := splitImage(gw.Spec.Processor.Image)
+	procRepo, procTag := splitImage(images.Processor)
 	processor := map[string]interface{}{
 		"enabled": true,
 		"image": map[string]interface{}{
@@ -273,7 +284,7 @@ func specToHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string) map[
 	vals["processor"] = processor
 
 	// --- GC ---
-	gcRepo, gcTag := splitImage(gw.Spec.GC.Image)
+	gcRepo, gcTag := splitImage(images.GC)
 	gc := map[string]interface{}{
 		"enabled": true,
 		"image": map[string]interface{}{

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -16,6 +16,16 @@ func testSecretName(gw *batchv1alpha1.LLMBatchGateway) string {
 	return gw.Spec.SecretRef.Name
 }
 
+// testImages returns the component images used in tests, simulating what the
+// operator reads from its environment (params.env) in production.
+func testImages() ComponentImages {
+	return ComponentImages{
+		APIServer: "ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest",
+		Processor: "ghcr.io/llm-d-incubation/batch-gateway-processor:latest",
+		GC:        "ghcr.io/llm-d-incubation/batch-gateway-gc:latest",
+	}
+}
+
 func TestSplitImage(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -106,7 +116,6 @@ func TestSpecToHelmValues(t *testing.T) {
 			},
 			APIServer: batchv1alpha1.APIServerSpec{
 				Replicas: &replicas,
-				Image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver:v0.1.0",
 				Resources: &corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1000m"),
@@ -116,20 +125,22 @@ func TestSpecToHelmValues(t *testing.T) {
 			},
 			Processor: batchv1alpha1.ProcessorSpec{
 				Replicas: &replicas,
-				Image:    "ghcr.io/llm-d-incubation/batch-gateway-processor:v0.1.0",
 				GlobalInferenceGateway: &batchv1alpha1.InferenceGatewaySpec{
 					URL:            "http://inference-gateway:8000",
 					RequestTimeout: "5m",
 				},
 			},
 			GC: batchv1alpha1.GCSpec{
-				Image:    "ghcr.io/llm-d-incubation/batch-gateway-gc:v0.1.0",
 				Interval: "30m",
 			},
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), ComponentImages{
+		APIServer: "ghcr.io/llm-d-incubation/batch-gateway-apiserver:v0.1.0",
+		Processor: "ghcr.io/llm-d-incubation/batch-gateway-processor:v0.1.0",
+		GC:        "ghcr.io/llm-d-incubation/batch-gateway-gc:v0.1.0",
+	})
 
 	t.Run("global secret name", func(t *testing.T) {
 		global, ok := vals["global"].(map[string]interface{})
@@ -211,7 +222,7 @@ func TestSpecToHelmValues_Monitoring(t *testing.T) {
 	gw := minimalGateway()
 	gw.Spec.Monitoring = &batchv1alpha1.MonitoringSpec{Enabled: true}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	t.Run("service monitor enabled", func(t *testing.T) {
 		apiserver := vals["apiserver"].(map[string]interface{})
@@ -260,7 +271,7 @@ func TestSpecToHelmValues_TLS(t *testing.T) {
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	tls := apiserver["tls"].(map[string]interface{})
@@ -291,7 +302,7 @@ func TestSpecToHelmValues_HTTPRoute(t *testing.T) {
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	hr := apiserver["httpRoute"].(map[string]interface{})
@@ -316,7 +327,7 @@ func TestSpecToHelmValues_HTTPRoute(t *testing.T) {
 
 func TestNewHelmRenderer(t *testing.T) {
 	t.Run("valid chart path", func(t *testing.T) {
-		renderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway")
+		renderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway", testImages())
 		if err != nil {
 			t.Fatalf("NewHelmRenderer() error: %v", err)
 		}
@@ -329,7 +340,7 @@ func TestNewHelmRenderer(t *testing.T) {
 	})
 
 	t.Run("invalid chart path", func(t *testing.T) {
-		_, err := NewHelmRenderer("/nonexistent/path")
+		_, err := NewHelmRenderer("/nonexistent/path", testImages())
 		if err == nil {
 			t.Fatal("expected error for invalid chart path")
 		}
@@ -337,7 +348,7 @@ func TestNewHelmRenderer(t *testing.T) {
 }
 
 func TestRenderChart(t *testing.T) {
-	renderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway")
+	renderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway", testImages())
 	if err != nil {
 		t.Fatalf("NewHelmRenderer() error: %v", err)
 	}
@@ -387,7 +398,7 @@ func TestRenderChart(t *testing.T) {
 }
 
 func TestRenderChart_WithMonitoring(t *testing.T) {
-	renderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway")
+	renderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway", testImages())
 	if err != nil {
 		t.Fatalf("NewHelmRenderer() error: %v", err)
 	}
@@ -430,7 +441,7 @@ func TestSpecToHelmValues_Logging(t *testing.T) {
 		Logging: &batchv1alpha1.LoggingConfig{Verbosity: 4},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	t.Run("apiserver logging verbosity", func(t *testing.T) {
 		apiserver := vals["apiserver"].(map[string]interface{})
@@ -474,7 +485,7 @@ func TestSpecToHelmValues_FSStorage(t *testing.T) {
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	global := vals["global"].(map[string]interface{})
 	fc := global["fileClient"].(map[string]interface{})
@@ -510,7 +521,7 @@ func TestSpecToHelmValues_OTEL(t *testing.T) {
 		PostgresqlTracing: true,
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	global := vals["global"].(map[string]interface{})
 	otel := global["otel"].(map[string]interface{})
@@ -536,7 +547,7 @@ func TestSpecToHelmValues_TLSSecretName(t *testing.T) {
 		SecretName: "my-tls-secret",
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	tls := apiserver["tls"].(map[string]interface{})
@@ -556,7 +567,7 @@ func TestSpecToHelmValues_TLSDNSNames(t *testing.T) {
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	tls := apiserver["tls"].(map[string]interface{})
@@ -583,7 +594,7 @@ func TestSpecToHelmValues_HTTPRouteAnnotations(t *testing.T) {
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	hr := apiserver["httpRoute"].(map[string]interface{})
@@ -603,7 +614,7 @@ func TestSpecToHelmValues_ModelGateways(t *testing.T) {
 		"model-a": {URL: "http://model-a:8000", RequestTimeout: "2m"},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	processor := vals["processor"].(map[string]interface{})
 	config := processor["config"].(map[string]interface{})
@@ -624,7 +635,7 @@ func TestSpecToHelmValues_PrometheusRule(t *testing.T) {
 		Labels:  map[string]string{"prometheus": "kube-prometheus"},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	pr := vals["prometheusRule"].(map[string]interface{})
 	if got := pr["enabled"]; got != true {
@@ -656,7 +667,7 @@ func TestSpecToHelmValues_APIServerConfig(t *testing.T) {
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	config := apiserver["config"].(map[string]interface{})
@@ -714,7 +725,7 @@ func TestSpecToHelmValues_ProcessorConfig(t *testing.T) {
 		EnablePprof:                    true,
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	processor := vals["processor"].(map[string]interface{})
 	config := processor["config"].(map[string]interface{})
@@ -752,7 +763,7 @@ func TestSpecToHelmValues_GCConfig(t *testing.T) {
 		MaxConcurrency: 10,
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	gc := vals["gc"].(map[string]interface{})
 	config := gc["config"].(map[string]interface{})
@@ -773,7 +784,7 @@ func TestSpecToHelmValues_InferenceGatewayMaxRetries(t *testing.T) {
 		MaxRetries: &maxRetries,
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	processor := vals["processor"].(map[string]interface{})
 	config := processor["config"].(map[string]interface{})
@@ -796,7 +807,7 @@ func TestSpecToHelmValues_ResourceRequirements(t *testing.T) {
 		},
 	}
 
-	vals := specToHelmValues(gw, testSecretName(gw))
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
 
 	apiserver := vals["apiserver"].(map[string]interface{})
 	res := apiserver["resources"].(map[string]interface{})
@@ -838,17 +849,14 @@ func minimalGateway() *batchv1alpha1.LLMBatchGateway {
 			},
 			APIServer: batchv1alpha1.APIServerSpec{
 				Replicas: &replicas,
-				Image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest",
 			},
 			Processor: batchv1alpha1.ProcessorSpec{
 				Replicas: &replicas,
-				Image:    "ghcr.io/llm-d-incubation/batch-gateway-processor:latest",
 				GlobalInferenceGateway: &batchv1alpha1.InferenceGatewaySpec{
 					URL: "http://inference-gateway:8000",
 				},
 			},
 			GC: batchv1alpha1.GCSpec{
-				Image:    "ghcr.io/llm-d-incubation/batch-gateway-gc:latest",
 				Interval: "30m",
 			},
 		},

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -40,18 +40,15 @@ func newTestGateway(name string) *batchv1alpha1.LLMBatchGateway {
 			},
 			APIServer: batchv1alpha1.APIServerSpec{
 				Replicas: ptr.To(int32(1)),
-				Image:    "test-apiserver:latest",
 			},
 			Processor: batchv1alpha1.ProcessorSpec{
 				Replicas: ptr.To(int32(1)),
-				Image:    "test-processor:latest",
 				GlobalInferenceGateway: &batchv1alpha1.InferenceGatewaySpec{
 					URL:            "http://inference-gw:8000",
 					RequestTimeout: "5m",
 				},
 			},
 			GC: batchv1alpha1.GCSpec{
-				Image:    "test-gc:latest",
 				Interval: "30m",
 			},
 		},
@@ -61,7 +58,7 @@ func newTestGateway(name string) *batchv1alpha1.LLMBatchGateway {
 func TestReconcile(t *testing.T) {
 	ctx := context.Background()
 
-	helmRenderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway")
+	helmRenderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway", testImages())
 	if err != nil {
 		t.Fatalf("NewHelmRenderer() error: %v", err)
 	}
@@ -649,7 +646,7 @@ func isOwnedByUID(refs []metav1.OwnerReference, uid types.UID) bool {
 func TestReconcileTimeout(t *testing.T) {
 	ctx := context.Background()
 
-	helmRenderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway")
+	helmRenderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway", testImages())
 	if err != nil {
 		t.Fatalf("NewHelmRenderer() error: %v", err)
 	}

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -20,7 +20,7 @@ import (
 func TestReconcileErrorMetricIncrement(t *testing.T) {
 	ctx := context.Background()
 
-	helmRenderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway")
+	helmRenderer, err := NewHelmRenderer("../../batch-gateway/charts/batch-gateway", testImages())
 	if err != nil {
 		t.Fatalf("NewHelmRenderer() error: %v", err)
 	}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- remove image from llmbatchgateway CR:  user should not be able to set image themselves this is breaking downstream
- params.env is the source of the truth where images should be
- kustomize get value and set as env to batch-gateway-operator deployment for production use.
- local dev test, read file and inject into manager.yaml for test.
- opendatahub-operator inject downstream images in params.env before deploy batch-gateway-operator.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make dev-rm-cluster`
change params.env to a different image tag for apiserver image "odh-pr"
`make dev-deploy`
check env on deployment/batch-gateway-operator
```
LLM_D_BATCH_GATEWAY_APISERVER_IMAGE:  quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-pr
LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE:  quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
LLM_D_BATCH_GATEWAY_GC_IMAGE:         quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable
```
check image used in api server
`kubectl get deployment batch-gateway-apiserver -n default  -o jsonpath='{range .spec.template.spec.containers[?(@.name=="apiserver")]}{.image}{"\n"}{end}'`
quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-pr

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the per-resource `image` field from APIServer, Processor, and GC in LLMBatchGateway CRs; images are no longer set on the CR.

* **Configuration**
  * Component images are now provided centrally via operator parameters and environment variables; sample manifests and dev deploy flow updated to reflect this.
  * Operator deployment now exposes image environment variables for APIServer, Processor, and GC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->