### PR TITLE
security: remove deletecollection from aggregate-to-edit role

### DIFF
--- a/config/rbac/aggregate_roles.yaml
+++ b/config/rbac/aggregate_roles.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups: ["batch.llm-d.ai"]
   resources: ["llmbatchgateways"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["batch.llm-d.ai"]
   resources: ["llmbatchgateways/status"]
   verbs: ["get"]


### PR DESCRIPTION
The TP security scan (RHOAIENG-63961) flagged `deletecollection` in the aggregate-to-edit ClusterRole as excessive privilege. Users with the `edit` role should not be able to bulk-delete custom resources — that capability should be reserved for `admin`.


- Removes `deletecollection` from the `llmbatchgateway-admin` ClusterRole that aggregates into both `admin` and `edit`. After this change, only individual `delete` is available at the edit level.

