### PR TITLE
fix: remove platform.opendatahub.io/part-of label from base kustomization

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -11,7 +11,6 @@ labels:
       app.kubernetes.io/name: llm-d-batch-gateway-operator
       app.kubernetes.io/component: llm-d-batch-gateway
       app.kubernetes.io/part-of: llm-d-batch-gateway
-      platform.opendatahub.io/part-of: llm-d-batch-gateway
 
 patches:
   - path: manager_metrics_patch.yaml


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

Remove `platform.opendatahub.io/part-of` label from `config/base/kustomization.yaml`.

This label should be injected by the parent operator (ai-gateway-operator) at render time, not hardcoded in batch-gateway-operator. The hardcoded value (llm-d-batch-gateway) conflicts with the value ai-gateway-operator injects (aigateway), causing the deployment status check to report 0/0 deployments ready.

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
