### PR TITLE
chore: update GHCR image references from llm-d-incubation to llm-d org

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ This creates a Kind cluster and deploys PostgreSQL, Redis, MinIO, a vLLM simulat
 | `POSTGRESQL_PASSWORD` | `postgres` | PostgreSQL password |
 | `MINIO_ACCESS_KEY` | `minioadmin` | MinIO access key |
 | `MINIO_SECRET_KEY` | `minioadmin` | MinIO secret key |
-| `APISERVER_IMG` | `ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest` | API server image |
-| `PROCESSOR_IMG` | `ghcr.io/llm-d-incubation/batch-gateway-processor:latest` | Processor image |
-| `GC_IMG` | `ghcr.io/llm-d-incubation/batch-gateway-gc:latest` | GC image |
+| `APISERVER_IMG` | `ghcr.io/llm-d/batch-gateway-apiserver:latest` | API server image |
+| `PROCESSOR_IMG` | `ghcr.io/llm-d/batch-gateway-processor:latest` | Processor image |
+| `GC_IMG` | `ghcr.io/llm-d/batch-gateway-gc:latest` | GC image |
 | `APISERVER_NODE_PORT` | `30080` | NodePort for API server |
 
 Once the environment is up, run the upstream e2e tests:

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -20,9 +20,9 @@ func testSecretName(gw *batchv1alpha1.LLMBatchGateway) string {
 // operator reads from its environment (params.env) in production.
 func testImages() ComponentImages {
 	return ComponentImages{
-		APIServer: "ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest",
-		Processor: "ghcr.io/llm-d-incubation/batch-gateway-processor:latest",
-		GC:        "ghcr.io/llm-d-incubation/batch-gateway-gc:latest",
+		APIServer: "ghcr.io/llm-d/batch-gateway-apiserver:latest",
+		Processor: "ghcr.io/llm-d/batch-gateway-processor:latest",
+		GC:        "ghcr.io/llm-d/batch-gateway-gc:latest",
 	}
 }
 
@@ -35,20 +35,20 @@ func TestSplitImage(t *testing.T) {
 	}{
 		{
 			name:     "standard image with tag",
-			image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver:v0.1.0",
-			wantRepo: "ghcr.io/llm-d-incubation/batch-gateway-apiserver",
+			image:    "ghcr.io/llm-d/batch-gateway-apiserver:v0.1.0",
+			wantRepo: "ghcr.io/llm-d/batch-gateway-apiserver",
 			wantTag:  "v0.1.0",
 		},
 		{
 			name:     "image with latest tag",
-			image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest",
-			wantRepo: "ghcr.io/llm-d-incubation/batch-gateway-apiserver",
+			image:    "ghcr.io/llm-d/batch-gateway-apiserver:latest",
+			wantRepo: "ghcr.io/llm-d/batch-gateway-apiserver",
 			wantTag:  "latest",
 		},
 		{
 			name:     "image without tag",
-			image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver",
-			wantRepo: "ghcr.io/llm-d-incubation/batch-gateway-apiserver",
+			image:    "ghcr.io/llm-d/batch-gateway-apiserver",
+			wantRepo: "ghcr.io/llm-d/batch-gateway-apiserver",
 			wantTag:  "latest",
 		},
 		{
@@ -65,14 +65,14 @@ func TestSplitImage(t *testing.T) {
 		},
 		{
 			name:     "image with sha tag prefix",
-			image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver:sha-abc123",
-			wantRepo: "ghcr.io/llm-d-incubation/batch-gateway-apiserver",
+			image:    "ghcr.io/llm-d/batch-gateway-apiserver:sha-abc123",
+			wantRepo: "ghcr.io/llm-d/batch-gateway-apiserver",
 			wantTag:  "sha-abc123",
 		},
 		{
 			name:     "digest splits so chart reconstructs repo@sha256:hex correctly",
-			image:    "ghcr.io/llm-d-incubation/batch-gateway-apiserver@sha256:abc123def456",
-			wantRepo: "ghcr.io/llm-d-incubation/batch-gateway-apiserver@sha256",
+			image:    "ghcr.io/llm-d/batch-gateway-apiserver@sha256:abc123def456",
+			wantRepo: "ghcr.io/llm-d/batch-gateway-apiserver@sha256",
 			wantTag:  "abc123def456",
 		},
 		{
@@ -137,9 +137,9 @@ func TestSpecToHelmValues(t *testing.T) {
 	}
 
 	vals := specToHelmValues(gw, testSecretName(gw), ComponentImages{
-		APIServer: "ghcr.io/llm-d-incubation/batch-gateway-apiserver:v0.1.0",
-		Processor: "ghcr.io/llm-d-incubation/batch-gateway-processor:v0.1.0",
-		GC:        "ghcr.io/llm-d-incubation/batch-gateway-gc:v0.1.0",
+		APIServer: "ghcr.io/llm-d/batch-gateway-apiserver:v0.1.0",
+		Processor: "ghcr.io/llm-d/batch-gateway-processor:v0.1.0",
+		GC:        "ghcr.io/llm-d/batch-gateway-gc:v0.1.0",
 	})
 
 	t.Run("global secret name", func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestSpecToHelmValues(t *testing.T) {
 	t.Run("apiserver image split", func(t *testing.T) {
 		apiserver := vals["apiserver"].(map[string]interface{})
 		img := apiserver["image"].(map[string]interface{})
-		if got := img["repository"]; got != "ghcr.io/llm-d-incubation/batch-gateway-apiserver" {
+		if got := img["repository"]; got != "ghcr.io/llm-d/batch-gateway-apiserver" {
 			t.Errorf("image.repository = %v", got)
 		}
 		if got := img["tag"]; got != "v0.1.0" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update upstream GHCR container image references from the old `llm-d-incubation` org to the new `llm-d` org, following the batch-gateway repo transfer from `llm-d-incubation/batch-gateway` to `llm-d/llm-d-batch-gateway` (ref: https://github.com/llm-d/llm-d-batch-gateway/issues/482, item 7).


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references from the incubation registry to the production registry for E2E dev-deploy environments, including API server, processor, and garbage collection components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->