### PR TITLE
security: harden LLMBatchGateway validation and operator manifests

### DIFF
--- a/.tekton/odh-batch-gateway-operator-pull-request.yaml
+++ b/.tekton/odh-batch-gateway-operator-pull-request.yaml
@@ -40,7 +40,7 @@ spec:
     - name: url
       value: https://github.com/opendatahub-io/odh-konflux-central.git
     - name: revision
-      value: main
+      value: fe0f0aa1ba2c59ba013d8b973642edaab17bb967
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:

--- a/.tekton/odh-batch-gateway-operator-push.yaml
+++ b/.tekton/odh-batch-gateway-operator-push.yaml
@@ -35,7 +35,7 @@ spec:
     - name: url
       value: https://github.com/opendatahub-io/odh-konflux-central.git
     - name: revision
-      value: main
+      value: fe0f0aa1ba2c59ba013d8b973642edaab17bb967
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunTemplate:

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -122,6 +122,7 @@ type S3StorageSpec struct {
 
 	// Endpoint overrides the S3 endpoint URL for non-AWS providers (e.g. MinIO).
 	// +kubebuilder:validation:MaxLength=2048
+	// +kubebuilder:validation:Pattern=`^https?://.+$`
 	Endpoint string `json:"endpoint,omitempty"`
 
 	// AccessKeyID is the S3 access key ID (non-sensitive). The corresponding
@@ -274,10 +275,12 @@ type ProcessorSpec struct {
 }
 
 // InferenceGatewaySpec configures a connection to an inference gateway.
+// +kubebuilder:validation:XValidation:rule="!has(self.tlsInsecureSkipVerify) || !self.tlsInsecureSkipVerify",message="tlsInsecureSkipVerify is not allowed; configure trusted CA certificates instead"
 type InferenceGatewaySpec struct {
 	// URL is the base URL of the inference gateway (e.g. "http://gateway.svc:8000").
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=2048
+	// +kubebuilder:validation:Pattern=`^https?://.+$`
 	URL string `json:"url"`
 
 	// RequestTimeout is the maximum time to wait for a single inference response (e.g. "5m").
@@ -398,6 +401,7 @@ type PrometheusRuleSpec struct {
 type OTELSpec struct {
 	// Endpoint is the OTLP gRPC or HTTP endpoint (e.g. "http://collector:4317").
 	// +kubebuilder:validation:MaxLength=2048
+	// +kubebuilder:validation:Pattern=`^https?://.+$`
 	Endpoint string `json:"endpoint,omitempty"`
 
 	// Insecure disables TLS for the OTLP connection.

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -284,6 +284,7 @@ spec:
                         description: Endpoint overrides the S3 endpoint URL for non-AWS
                           providers (e.g. MinIO).
                         maxLength: 2048
+                        pattern: ^https?://.+$
                         type: string
                       prefix:
                         description: Prefix is an optional key prefix applied to all
@@ -401,6 +402,7 @@ spec:
                     description: Endpoint is the OTLP gRPC or HTTP endpoint (e.g.
                       "http://collector:4317").
                     maxLength: 2048
+                    pattern: ^https?://.+$
                     type: string
                   insecure:
                     description: Insecure disables TLS for the OTLP connection.
@@ -527,10 +529,15 @@ spec:
                         description: URL is the base URL of the inference gateway
                           (e.g. "http://gateway.svc:8000").
                         maxLength: 2048
+                        pattern: ^https?://.+$
                         type: string
                     required:
                     - url
                     type: object
+                    x-kubernetes-validations:
+                    - message: tlsInsecureSkipVerify is not allowed; configure trusted
+                        CA certificates instead
+                      rule: '!has(self.tlsInsecureSkipVerify) || !self.tlsInsecureSkipVerify'
                   modelGateways:
                     additionalProperties:
                       description: InferenceGatewaySpec configures a connection to
@@ -582,10 +589,15 @@ spec:
                           description: URL is the base URL of the inference gateway
                             (e.g. "http://gateway.svc:8000").
                           maxLength: 2048
+                          pattern: ^https?://.+$
                           type: string
                       required:
                       - url
                       type: object
+                      x-kubernetes-validations:
+                      - message: tlsInsecureSkipVerify is not allowed; configure trusted
+                          CA certificates instead
+                        rule: '!has(self.tlsInsecureSkipVerify) || !self.tlsInsecureSkipVerify'
                     description: |-
                       ModelGateways maps model names to per-model inference gateway configurations,
                       overriding GlobalInferenceGateway for those models.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,8 @@ spec:
           value: quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
         - name: LLM_D_BATCH_GATEWAY_GC_IMAGE
           value: quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable
+        - name: GOMEMLIMIT
+          value: 200MiB
         ports:
         - containerPort: 8443
           name: metrics

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -375,9 +375,6 @@ func inferenceGatewayToMap(gw *batchv1alpha1.InferenceGatewaySpec) map[string]in
 	}
 	setIfNotEmpty(m, "initialBackoff", gw.InitialBackoff)
 	setIfNotEmpty(m, "maxBackoff", gw.MaxBackoff)
-	if gw.TLSInsecureSkipVerify {
-		m["tlsInsecureSkipVerify"] = true
-	}
 	setIfNotEmpty(m, "tlsCaCertFile", gw.TLSCACertFile)
 	setIfNotEmpty(m, "tlsClientCertFile", gw.TLSClientCertFile)
 	setIfNotEmpty(m, "tlsClientKeyFile", gw.TLSClientKeyFile)

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -794,6 +794,23 @@ func TestSpecToHelmValues_InferenceGatewayMaxRetries(t *testing.T) {
 	}
 }
 
+func TestSpecToHelmValues_OmitsTLSInsecureSkipVerify(t *testing.T) {
+	gw := minimalGateway()
+	gw.Spec.Processor.GlobalInferenceGateway = &batchv1alpha1.InferenceGatewaySpec{
+		URL:                   "https://gw:8443",
+		TLSInsecureSkipVerify: true,
+	}
+
+	vals := specToHelmValues(gw, testSecretName(gw), testImages())
+
+	processor := vals["processor"].(map[string]interface{})
+	config := processor["config"].(map[string]interface{})
+	gig := config["globalInferenceGateway"].(map[string]interface{})
+	if _, found := gig["tlsInsecureSkipVerify"]; found {
+		t.Fatal("tlsInsecureSkipVerify should not be rendered into Helm values")
+	}
+}
+
 func TestSpecToHelmValues_ResourceRequirements(t *testing.T) {
 	gw := minimalGateway()
 	gw.Spec.APIServer.Resources = &corev1.ResourceRequirements{

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -139,7 +139,8 @@ func (r *LLMBatchGatewayReconciler) reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if err := validateSpec(&gw); err != nil {
-		for _, condType := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable} {
+		gw.Status.ObservedGeneration = gw.Generation
+		for _, condType := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable, conditionGCAvailable} {
 			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 				Type:               condType,
 				Status:             metav1.ConditionFalse,
@@ -151,6 +152,7 @@ func (r *LLMBatchGatewayReconciler) reconcile(ctx context.Context, req ctrl.Requ
 		r.Recorder.Eventf(&gw, corev1.EventTypeWarning, "ValidationFailed", "Spec validation failed: %s", err)
 		if statusErr := NewStatusPatch(gw.ResourceVersion).
 			Add(conditionsStatusField, gw.Status.Conditions).
+			Add(observedGenerationStatusField, gw.Status.ObservedGeneration).
 			Apply(ctx, r.Client, &gw); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("patching status after validation failure: %w", statusErr)
 		}
@@ -170,6 +172,7 @@ func (r *LLMBatchGatewayReconciler) reconcile(ctx context.Context, req ctrl.Requ
 			reason, permanent = reasonSecretRefImmutable, true
 		}
 		if permanent {
+			gw.Status.ObservedGeneration = gw.Generation
 			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 				Type:               conditionReady,
 				Status:             metav1.ConditionFalse,
@@ -180,6 +183,7 @@ func (r *LLMBatchGatewayReconciler) reconcile(ctx context.Context, req ctrl.Requ
 			r.Recorder.Eventf(&gw, corev1.EventTypeWarning, reason, "%s", err)
 			if statusErr := NewStatusPatch(gw.ResourceVersion).
 				Add(conditionsStatusField, gw.Status.Conditions).
+				Add(observedGenerationStatusField, gw.Status.ObservedGeneration).
 				Apply(ctx, r.Client, &gw); statusErr != nil {
 				return ctrl.Result{}, fmt.Errorf("patching status after %s: %w", reason, statusErr)
 			}
@@ -200,6 +204,7 @@ func (r *LLMBatchGatewayReconciler) reconcile(ctx context.Context, req ctrl.Requ
 
 	objects, err := r.HelmRenderer.RenderChart(&gw, localSecretName)
 	if err != nil {
+		gw.Status.ObservedGeneration = gw.Generation
 		meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 			Type:               conditionReady,
 			Status:             metav1.ConditionFalse,
@@ -210,6 +215,7 @@ func (r *LLMBatchGatewayReconciler) reconcile(ctx context.Context, req ctrl.Requ
 		r.Recorder.Eventf(&gw, corev1.EventTypeWarning, "RenderFailed", "Helm chart render failed: %s", err)
 		if statusErr := NewStatusPatch(gw.ResourceVersion).
 			Add(conditionsStatusField, gw.Status.Conditions).
+			Add(observedGenerationStatusField, gw.Status.ObservedGeneration).
 			Apply(ctx, r.Client, &gw); statusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("rendering chart: %w; also failed to patch status: %w", err, statusErr)
 		}
@@ -417,6 +423,10 @@ func (r *LLMBatchGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		func(ctx context.Context, obj client.Object) []reconcile.Request {
 			var gwList batchv1alpha1.LLMBatchGatewayList
 			if err := r.List(ctx, &gwList); err != nil {
+				log.FromContext(ctx).Error(err, "listing LLMBatchGateways for Secret watch", "secret", types.NamespacedName{
+					Namespace: obj.GetNamespace(),
+					Name:      obj.GetName(),
+				})
 				return nil
 			}
 			var reqs []reconcile.Request
@@ -442,6 +452,10 @@ func (r *LLMBatchGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		func(ctx context.Context, obj client.Object) []reconcile.Request {
 			var gwList batchv1alpha1.LLMBatchGatewayList
 			if err := r.List(ctx, &gwList); err != nil {
+				log.FromContext(ctx).Error(err, "listing LLMBatchGateways for ReferenceGrant watch", "referenceGrant", types.NamespacedName{
+					Namespace: obj.GetNamespace(),
+					Name:      obj.GetName(),
+				})
 				return nil
 			}
 			var reqs []reconcile.Request

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -232,7 +232,7 @@ func TestReconcile(t *testing.T) {
 			conditionTypes[c.Type] = true
 		}
 
-		for _, ct := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable} {
+		for _, ct := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable, conditionGCAvailable} {
 			if !conditionTypes[ct] {
 				t.Errorf("missing condition %q", ct)
 			}
@@ -384,7 +384,7 @@ func TestReconcile(t *testing.T) {
 			t.Fatalf("getting updated CR: %v", err)
 		}
 
-		for _, condType := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable} {
+		for _, condType := range []string{conditionReady, conditionAPIServerAvailable, conditionProcessorAvailable, conditionGCAvailable} {
 			found := false
 			for _, c := range updated.Status.Conditions {
 				if c.Type == condType {
@@ -401,6 +401,9 @@ func TestReconcile(t *testing.T) {
 			if !found {
 				t.Errorf("missing condition %s", condType)
 			}
+		}
+		if updated.Status.ObservedGeneration != updated.Generation {
+			t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, updated.Generation)
 		}
 
 		assertEvent(t, fakeRecorder, corev1.EventTypeWarning, "ValidationFailed")
@@ -441,6 +444,9 @@ func TestReconcile(t *testing.T) {
 				if c.Reason != "ValidationFailed" {
 					t.Errorf("Ready reason = %v, want ValidationFailed", c.Reason)
 				}
+				if updated.Status.ObservedGeneration != updated.Generation {
+					t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, updated.Generation)
+				}
 				return
 			}
 		}
@@ -474,6 +480,9 @@ func TestReconcile(t *testing.T) {
 				}
 				if c.Reason != reasonReferenceNotPermitted {
 					t.Errorf("Ready reason = %q, want %q", c.Reason, reasonReferenceNotPermitted)
+				}
+				if updated.Status.ObservedGeneration != updated.Generation {
+					t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, updated.Generation)
 				}
 				assertEvent(t, fakeRecorder, corev1.EventTypeWarning, reasonReferenceNotPermitted)
 				return
@@ -526,6 +535,9 @@ func TestReconcile(t *testing.T) {
 				}
 				if c.Reason != reasonSecretRefImmutable {
 					t.Errorf("Ready reason = %q, want %q", c.Reason, reasonSecretRefImmutable)
+				}
+				if updated.Status.ObservedGeneration != updated.Generation {
+					t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, updated.Generation)
 				}
 				assertEvent(t, fakeRecorder, corev1.EventTypeWarning, reasonSecretRefImmutable)
 				return


### PR DESCRIPTION
## Overview
The midstream security review still had a few actionable findings in the
batch-gateway operator itself before the vendored manifests can be synced
into `ai-gateway-operator`.
In particular, the LLMBatchGateway CRD still allowed insecure TLS
skip-verify settings, several URL/endpoint fields accepted arbitrary
strings, the operator deployment did not set `GOMEMLIMIT`, and the Tekton
pipeline references still used a mutable branch revision.


## Changes
- Pins both Tekton `odh-konflux-central` pipeline references to a commit SHA
- Adds CRD validation for LLMBatchGateway endpoint fields:
  - `spec.fileStorage.s3.endpoint`
  - `spec.otel.endpoint`
  - `spec.processor.globalInferenceGateway.url`
  - `spec.processor.modelGateways[*].url`
- Adds CEL validation to reject `tlsInsecureSkipVerify: true`
- Stops rendering `tlsInsecureSkipVerify` into Helm values
- Adds `GOMEMLIMIT=200MiB` to the operator deployment manifest
- Updates reconcile error paths so `status.observedGeneration` is patched
  consistently and validation failures also set `GCAvailable=False`
- Adds/updates controller tests for the new status behavior and Helm-value
  expectations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced secure protocol requirements for all endpoint configurations.
  * Blocked insecure TLS verification options to enhance security.
  * Improved status tracking accuracy during validation failures.
  * Optimized memory resource allocation for the manager.

* **Tests**
  * Expanded coverage for TLS security and status validation scenarios.

* **Chores**
  * Updated Tekton pipeline references to fixed commit versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->