### PR TITLE
backport:  Dockerfile.konflux from RHDS

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.8@sha256:75ecb48dfaec6655bd589091902e3b9328c300befba34cb06fc5e7323099e17d AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 ARG CGO_ENABLED=1
-#   BUILD_TYPE=CI for hermetic konflux build (downstream)
+# BUILD_TYPE=CI for hermetic konflux build (downstream)
 ARG BUILD_TYPE
 
 WORKDIR /opt/app-root/src
@@ -14,25 +14,28 @@ COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 
-RUN mkdir -p bin && \
-    CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    GOEXPERIMENT=strictfipsruntime \
-    go build -a -o bin/manager ./cmd/
-
 # Obtain the batch-gateway Helm chart into /tmp/batch-gateway-chart.
 COPY Makefile ./
-RUN if [ "${BUILD_TYPE}" = "CI" ]; then \
-        # hermetic: chart provided by the Konflux prefetch step (path set by the downstream prefetch config).
-        cp -r /cachi2/prefetched-charts/batch-gateway /tmp/batch-gateway-chart; \
-    else \
+
+RUN mkdir -p -m 777 /tmp/batch-gateway-chart
+# For all the crazy permisison denies
+COPY --chown=1001:0 Dockerfile prefetched-charts* /tmp/batch-gateway-chart/
+
+RUN if [ "${BUILD_TYPE}" != "CI" ]; then \
         make fetch-batch-gateway && \
         cp -r batch-gateway/charts/batch-gateway /tmp/batch-gateway-chart; \
     fi
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:d91be7cea9f03a757d69ad7fcdfcd7849dba820110e7980d5e2a1f46ed06ea3b
+RUN mkdir -p bin && \
+CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+GOEXPERIMENT=strictfipsruntime \
+go build -a -o bin/manager ./cmd/
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0
 WORKDIR /
 COPY --from=builder /opt/app-root/src/bin/manager /manager
 COPY --from=builder /tmp/batch-gateway-chart /charts/batch-gateway/
+RUN rm -f /charts/batch-gateway/Dockerfile
 
 USER 1001:1001
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
to make konflux work for both ODH and RHDS with the same dockerfile
without setting BUILD_TYPE=CI in odh, it falls back to "make" target 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container build to use refreshed base image digests for more consistent, secure builds across build and runtime stages.
  * Improved the batch-gateway chart staging workflow: chart inputs are prepared consistently, while chart fetching behaves differently in CI vs non-CI to reduce variability.
  * Refined final container packaging by cleaning up copied chart contents and adjusting the build/packaging steps for a more reliable runtime image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->