### PR TITLE
fix: flatten prefetched chart directory to avoid nested path in ODH build

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -23,7 +23,7 @@ COPY --chown=1001:0 Dockerfile prefetched-charts* /tmp/batch-gateway-chart/
 
 RUN if [ "${BUILD_TYPE}" != "CI" ]; then \
         make fetch-batch-gateway && \
-        cp -r batch-gateway/charts/batch-gateway /tmp/batch-gateway-chart; \
+        cp -r batch-gateway/charts/batch-gateway/* /tmp/batch-gateway-chart/; \
     fi
 
 RUN mkdir -p bin && \


### PR DESCRIPTION
## Description

The Dockerfile.konflux backport (27a22ad) broke the Helm chart path in image `quay.io/opendatahub/odh-batch-gateway-operator:odh-stable`. 

The chart ends up nested one level too deep:
- Current image layout:   `/charts/batch-gateway/batch-gateway/Chart.yaml`
- Expected image layout: `/charts/batch-gateway/Chart.yaml`

Operator crashes on startup: `loading chart from /charts/batch-gateway: Chart.yaml file is missing`

Fix: flatten the nested directory in non-CI mode.

### Reproduce

```bash
# Verify the bug in current odh-stable image:
cid=$(podman create --override-os linux --override-arch amd64 quay.io/opendatahub/odh-batch-gateway-operator:odh-stable)
podman cp "$cid:/charts/" /tmp/charts
find /tmp/charts -name Chart.yaml
# Output: /tmp/charts/batch-gateway/batch-gateway/Chart.yaml  ← nested
podman rm "$cid"
```

## How Has This Been Tested?

Built with `Dockerfile.konflux`, verified image layout:
```
/charts/batch-gateway/Chart.yaml
/charts/batch-gateway/values.yaml
/charts/batch-gateway/templates/...
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work