### PR TITLE
chore: harden workflow permissions and persist-credentials

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Fetch batch-gateway chart
         run: make fetch-batch-gateway

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -27,9 +27,13 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,13 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -32,9 +36,13 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:

--- a/.github/workflows/refresh-prefetched-charts.yml
+++ b/.github/workflows/refresh-prefetched-charts.yml
@@ -18,6 +18,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Regenerate prefetched-charts from BATCH_GATEWAY_REF
         run: make sync-prefetched-charts

--- a/.github/workflows/verify-kustomize.yml
+++ b/.github/workflows/verify-kustomize.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5


### PR DESCRIPTION
 ## Description

Addresses findings from #55.

1. Add `persist-credentials: false` to all checkout steps across 5 workflows to prevent GITHUB_TOKEN from persisting in .git/config (CWE-522).
2. Add explicit `permissions: contents: read` to `ci.yml` (lint, test) and `ci-integration-tests.yml` jobs that inherited broad repo defaults.

Also added `persist-credentials: false` to `ci-image.yml` and `verify-kustomize.yml` for consistency. Both already had permissions blocks but were missing credential cleanup.

Closes #55

## How Has This Been Tested?

- ci.yml, ci-integration-tests.yml, verify-kustomize.yml: Verified by CI running on this PR
- refresh-prefetched-charts.yml: Runs on main push only. `peter-evans/create-pull-request` uses its own `token` input, not .git/config credentials.
- ci-image.yml: Runs on main push only. `docker/login-action` uses its own credentials, not .git/config.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened CI workflow settings to avoid keeping Git credentials after checkout.
  * Limited workflow permissions to read-only access where needed.
  * Improved consistency across build, test, integration, and verification jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->