### PR TITLE
Test/e2e rhoai coverage 69

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ verify-manifests: manifests kustomize ## Verify that every overlay builds succes
 ## Deploy (kustomize)
 
 .PHONY: deploy
-deploy: manifests
-	cd config/default && kustomize edit set image controller=$(IMG)
+deploy: manifests kustomize
+	cd config/default && $(KUSTOMIZE) edit set image controller=$(IMG)
 	kubectl apply -k config/default
 
 .PHONY: undeploy
@@ -118,8 +118,8 @@ undeploy:
 ## Dev (Kind)
 
 .PHONY: dev-deploy
-dev-deploy: fetch-batch-gateway
-	hack/dev-deploy.sh
+dev-deploy: kustomize fetch-batch-gateway
+	PATH="$(shell pwd)/bin:$$PATH" hack/dev-deploy.sh
 
 .PHONY: dev-clean
 dev-clean:

--- a/hack/dev-deploy.sh
+++ b/hack/dev-deploy.sh
@@ -59,6 +59,9 @@ detect_CONTAINER_TOOL() {
 
 check_prerequisites() {
     step "Checking prerequisites..."
+    if ! command -v kustomize &>/dev/null && [ -x "${OPERATOR_DIR}/bin/kustomize" ]; then
+        export PATH="${OPERATOR_DIR}/bin:${PATH}"
+    fi
     local missing=()
     for cmd in kubectl helm kind kustomize curl; do
         command -v "$cmd" &>/dev/null || missing+=("$cmd")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -15,6 +15,10 @@ var (
 func TestE2E(t *testing.T) {
 	t.Run("Operator", func(t *testing.T) {
 		t.Run("StatusConditions", testStatusConditions)
+		t.Run("OperandPodsReady", testOperandPodsReady)
+		t.Run("ServiceReachability", testServiceReachability)
+		t.Run("ReadyFalseConformance", testReadyFalseConformance)
+		t.Run("CRDeletionCleanup", testCRDeletionCleanup)
 		t.Run("OrphanCleanup", testOrphanCleanup)
 		t.Run("SpecUpdate", testSpecUpdate)
 		t.Run("ProcessorReplicasUpdate", testProcessorReplicasUpdate)
@@ -48,6 +52,81 @@ func testStatusConditions(t *testing.T) {
 		time.Sleep(pollInterval)
 	}
 	t.Fatalf("timed out waiting for status conditions: %v", expected)
+}
+
+func testOperandPodsReady(t *testing.T) {
+	for _, component := range []string{"apiserver", "processor", "gc"} {
+		t.Run(component, func(t *testing.T) {
+			waitForComponentPodsReady(t, testNamespace, testCRName, component, 120*time.Second)
+		})
+	}
+}
+
+func testServiceReachability(t *testing.T) {
+	serviceName := findServiceByComponent(t, testNamespace, testCRName, "apiserver")
+	waitForServiceEndpointsReady(t, serviceName, testNamespace, 60*time.Second)
+
+	apiPort := getServicePortByAnyName(t, serviceName, testNamespace, "http", "https")
+	withServicePortForward(t, testNamespace, serviceName, apiPort, func(baseURL string) {
+		requireHTTPSuccess(t, baseURL+"/v1/files")
+	})
+
+	observabilityPort := getServicePortByName(t, serviceName, testNamespace, "observability")
+	withServicePortForward(t, testNamespace, serviceName, observabilityPort, func(baseURL string) {
+		requireHTTPStatus(t, baseURL+"/ready", 200)
+	})
+}
+
+func testReadyFalseConformance(t *testing.T) {
+	t.Cleanup(snapshotCRSpec(t, testCRName, testNamespace))
+	deploymentName := findDeploymentByComponent(t, testNamespace, testCRName, "apiserver")
+	originalReplicas := getDeploymentReplicas(t, deploymentName, testNamespace)
+
+	kubectlPatch(t, llmBatchGatewayKind, testCRName, testNamespace, `{"spec":{"apiServer":{"replicas":0}}}`)
+
+	waitForConditionStatus(t, testCRName, testNamespace, "APIServerAvailable", "False", 90*time.Second)
+	waitForConditionStatus(t, testCRName, testNamespace, "Ready", "False", 90*time.Second)
+
+	kubectlPatch(t, llmBatchGatewayKind, testCRName, testNamespace,
+		fmt.Sprintf(`{"spec":{"apiServer":{"replicas":%d}}}`, originalReplicas))
+
+	waitForConditionStatus(t, testCRName, testNamespace, "APIServerAvailable", "True", 120*time.Second)
+	waitForConditionStatus(t, testCRName, testNamespace, "Ready", "True", 120*time.Second)
+	waitForComponentPodsReady(t, testNamespace, testCRName, "apiserver", 120*time.Second)
+}
+
+func testCRDeletionCleanup(t *testing.T) {
+	tempCRName := fmt.Sprintf("%s-cleanup-%d", testCRName, time.Now().UnixNano())
+	selector := fmt.Sprintf("app.kubernetes.io/instance=%s", tempCRName)
+
+	cloneExistingCR(t, testCRName, testNamespace, tempCRName)
+	t.Cleanup(func() {
+		kubectlDelete(t, llmBatchGatewayKind, tempCRName, testNamespace)
+	})
+
+	cr := kubectlGetJSON(t, llmBatchGatewayKind, tempCRName, testNamespace)
+	ownerUID := getObjectUID(t, cr)
+
+	for _, tc := range []struct {
+		resource string
+		minCount int
+	}{
+		{resource: "deployment", minCount: 3},
+		{resource: "service", minCount: 1},
+		{resource: "configmap", minCount: 3},
+	} {
+		items := waitForResourceCountAtLeast(t, tc.resource, testNamespace, selector, tc.minCount, 120*time.Second)
+		for _, item := range items {
+			if !hasOwnerUID(item, ownerUID) {
+				t.Fatalf("%s for %s is not owned by %s", tc.resource, tempCRName, ownerUID)
+			}
+		}
+	}
+
+	kubectlDelete(t, llmBatchGatewayKind, tempCRName, testNamespace)
+	for _, resource := range []string{"deployment", "service", "configmap"} {
+		waitForResourcesGoneBySelector(t, resource, testNamespace, selector, 120*time.Second)
+	}
 }
 
 func testOrphanCleanup(t *testing.T) {
@@ -183,7 +262,7 @@ func testResourcesUpdate(t *testing.T) {
 			deploymentName := findDeploymentByComponent(t, testNamespace, testCRName, tc.name)
 
 			kubectlPatch(t, llmBatchGatewayKind, testCRName, testNamespace,
-				`{"spec":{"` +tc.specField+`":{"resources":{"requests":{"cpu":"111m","memory":"99Mi"}}}}}`)
+				`{"spec":{"`+tc.specField+`":{"resources":{"requests":{"cpu":"111m","memory":"99Mi"}}}}}`)
 
 			deadline := time.Now().Add(60 * time.Second)
 			for time.Now().Before(deadline) {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,9 +1,12 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -12,7 +15,7 @@ import (
 )
 
 const (
-	pollInterval       = 2 * time.Second
+	pollInterval        = 2 * time.Second
 	llmBatchGatewayKind = "llmbatchgateway"
 )
 
@@ -25,6 +28,12 @@ func getEnvOrDefault(key, def string) string {
 
 func kubectl(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	return cmd.CombinedOutput()
+}
+
+func kubectlWithInput(ctx context.Context, input []byte, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	cmd.Stdin = bytes.NewReader(input)
 	return cmd.CombinedOutput()
 }
 
@@ -59,6 +68,33 @@ func kubectlPatch(t *testing.T, resource, name, namespace, patchJSON string) {
 	}
 }
 
+func kubectlCreateObject(t *testing.T, obj map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal object: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := kubectlWithInput(ctx, body, "create", "-f", "-")
+	if err != nil {
+		t.Fatalf("kubectl create object: %v\n%s", err, out)
+	}
+}
+
+func kubectlDelete(t *testing.T, resource, name, namespace string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := kubectl(ctx, "delete", resource, name, "-n", namespace, "--ignore-not-found=true", "--wait=true")
+	if err != nil {
+		t.Fatalf("kubectl delete %s %s: %v\n%s", resource, name, err, out)
+	}
+}
+
 func kubectlGetExists(t *testing.T, resource, name, namespace string) bool {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -90,6 +126,40 @@ func kubectlGetJSON(t *testing.T, resource, name, namespace string) map[string]a
 		t.Fatalf("parsing JSON for %s %s: %v", resource, name, err)
 	}
 	return result
+}
+
+func kubectlListJSON(t *testing.T, resource, namespace, selector string) []map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	args := []string{"get", resource, "-n", namespace, "-o", "json"}
+	if selector != "" {
+		args = append(args, "-l", selector)
+	}
+
+	out, err := kubectl(ctx, args...)
+	if err != nil {
+		t.Fatalf("kubectl list %s: %v\n%s", resource, err, out)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("parsing JSON list for %s: %v", resource, err)
+	}
+
+	rawItems, ok := result["items"].([]any)
+	if !ok {
+		return nil
+	}
+
+	items := make([]map[string]any, 0, len(rawItems))
+	for _, item := range rawItems {
+		if obj, ok := item.(map[string]any); ok {
+			items = append(items, obj)
+		}
+	}
+	return items
 }
 
 func waitForResourceExists(t *testing.T, resource, name, namespace string, timeout time.Duration) {
@@ -138,6 +208,22 @@ func getCRConditions(t *testing.T, crName, namespace string) []map[string]any {
 	return conditions
 }
 
+func waitForConditionStatus(t *testing.T, crName, namespace, conditionType, wantStatus string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, condition := range getCRConditions(t, crName, namespace) {
+			typ, _ := condition["type"].(string)
+			status, _ := condition["status"].(string)
+			if typ == conditionType && status == wantStatus {
+				return
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for condition %s=%s on %s", conditionType, wantStatus, crName)
+}
+
 func findDeploymentByComponent(t *testing.T, namespace, instance, component string) string {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -151,6 +237,23 @@ func findDeploymentByComponent(t *testing.T, namespace, instance, component stri
 	name := string(out)
 	if name == "" {
 		t.Fatalf("no deployment found with labels instance=%s,component=%s", instance, component)
+	}
+	return name
+}
+
+func findServiceByComponent(t *testing.T, namespace, instance, component string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	selector := fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=%s", instance, component)
+	out, err := kubectl(ctx, "get", "service", "-n", namespace, "-l", selector, "-o", "jsonpath={.items[0].metadata.name}")
+	if err != nil {
+		t.Fatalf("finding service with component=%s: %v\n%s", component, err, out)
+	}
+	name := string(out)
+	if name == "" {
+		t.Fatalf("no service found with labels instance=%s,component=%s", instance, component)
 	}
 	return name
 }
@@ -221,4 +324,301 @@ func getContainerResources(t *testing.T, deploymentName, namespace string) map[s
 	container, _ := containers[0].(map[string]any)
 	resources, _ := container["resources"].(map[string]any)
 	return resources
+}
+
+func getObjectUID(t *testing.T, obj map[string]any) string {
+	t.Helper()
+	metadata, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		t.Fatal("object has no metadata")
+	}
+	uid, _ := metadata["uid"].(string)
+	if uid == "" {
+		t.Fatal("object has no metadata.uid")
+	}
+	return uid
+}
+
+func hasOwnerUID(obj map[string]any, uid string) bool {
+	metadata, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		return false
+	}
+	rawRefs, ok := metadata["ownerReferences"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawRef := range rawRefs {
+		ref, ok := rawRef.(map[string]any)
+		if !ok {
+			continue
+		}
+		refUID, _ := ref["uid"].(string)
+		if refUID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForResourceCountAtLeast(t *testing.T, resource, namespace, selector string, minCount int, timeout time.Duration) []map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		items := kubectlListJSON(t, resource, namespace, selector)
+		if len(items) >= minCount {
+			return items
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for at least %d %s resources with selector %q", minCount, resource, selector)
+	return nil
+}
+
+func waitForResourcesGoneBySelector(t *testing.T, resource, namespace, selector string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(kubectlListJSON(t, resource, namespace, selector)) == 0 {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for %s resources with selector %q to be deleted", resource, selector)
+}
+
+func podReady(obj map[string]any) bool {
+	status, ok := obj["status"].(map[string]any)
+	if !ok {
+		return false
+	}
+	rawConditions, ok := status["conditions"].([]any)
+	if !ok {
+		return false
+	}
+	for _, rawCondition := range rawConditions {
+		condition, ok := rawCondition.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := condition["type"].(string)
+		value, _ := condition["status"].(string)
+		if typ == "Ready" && value == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForComponentPodsReady(t *testing.T, namespace, instance, component string, timeout time.Duration) {
+	t.Helper()
+	selector := fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=%s", instance, component)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pods := kubectlListJSON(t, "pods", namespace, selector)
+		if len(pods) == 0 {
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		allReady := true
+		for _, pod := range pods {
+			if !podReady(pod) {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for %s pods to become Ready", component)
+}
+
+func waitForServiceEndpointsReady(t *testing.T, serviceName, namespace string, timeout time.Duration) {
+	t.Helper()
+	selector := fmt.Sprintf("kubernetes.io/service-name=%s", serviceName)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		endpointSlices := kubectlListJSON(t, "endpointslice", namespace, selector)
+		for _, endpointSlice := range endpointSlices {
+			endpoints, ok := endpointSlice["endpoints"].([]any)
+			if !ok {
+				continue
+			}
+			for _, rawEndpoint := range endpoints {
+				endpoint, ok := rawEndpoint.(map[string]any)
+				if !ok {
+					continue
+				}
+				if rawAddresses, ok := endpoint["addresses"].([]any); ok && len(rawAddresses) > 0 {
+					conditions, _ := endpoint["conditions"].(map[string]any)
+					ready, _ := conditions["ready"].(bool)
+					if ready {
+						return
+					}
+				}
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("timed out waiting for endpoints on service %s", serviceName)
+}
+
+func getServicePortByName(t *testing.T, serviceName, namespace, portName string) int {
+	t.Helper()
+	service := kubectlGetJSON(t, "service", serviceName, namespace)
+	spec, ok := service["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("service %s has no spec", serviceName)
+	}
+	rawPorts, ok := spec["ports"].([]any)
+	if !ok {
+		t.Fatalf("service %s has no spec.ports", serviceName)
+	}
+	for _, rawPort := range rawPorts {
+		port, ok := rawPort.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := port["name"].(string)
+		value, _ := port["port"].(float64)
+		if name == portName {
+			return int(value)
+		}
+	}
+	t.Fatalf("service %s has no port named %s", serviceName, portName)
+	return 0
+}
+
+func getServicePortByAnyName(t *testing.T, serviceName, namespace string, portNames ...string) int {
+	t.Helper()
+	service := kubectlGetJSON(t, "service", serviceName, namespace)
+	spec, ok := service["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("service %s has no spec", serviceName)
+	}
+	rawPorts, ok := spec["ports"].([]any)
+	if !ok {
+		t.Fatalf("service %s has no spec.ports", serviceName)
+	}
+	for _, candidate := range portNames {
+		for _, rawPort := range rawPorts {
+			port, ok := rawPort.(map[string]any)
+			if !ok {
+				continue
+			}
+			name, _ := port["name"].(string)
+			value, _ := port["port"].(float64)
+			if name == candidate {
+				return int(value)
+			}
+		}
+	}
+	t.Fatalf("service %s has no port named any of %v", serviceName, portNames)
+	return 0
+}
+
+func withServicePortForward(t *testing.T, namespace, serviceName string, remotePort int, fn func(baseURL string)) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("allocate local port: %v", err)
+	}
+	localPort := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close local port listener: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var output bytes.Buffer
+	cmd := exec.CommandContext(ctx, "kubectl", "-n", namespace, "port-forward", "service/"+serviceName, fmt.Sprintf("%d:%d", localPort, remotePort))
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start port-forward for service %s: %v", serviceName, err)
+	}
+
+	done := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = cmd.Wait()
+		close(done)
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	address := fmt.Sprintf("127.0.0.1:%d", localPort)
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", address, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			fn("http://" + address)
+			return
+		}
+
+		select {
+		case <-done:
+			t.Fatalf("port-forward for service %s exited early: %v\n%s", serviceName, waitErr, output.String())
+		default:
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for service %s port-forward\n%s", serviceName, output.String())
+}
+
+func requireHTTPStatus(t *testing.T, url string, want int) {
+	t.Helper()
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != want {
+		t.Fatalf("GET %s returned status %d, want %d", url, resp.StatusCode, want)
+	}
+}
+
+func requireHTTPSuccess(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("GET %s returned status %d, want 2xx", url, resp.StatusCode)
+	}
+}
+
+func cloneExistingCR(t *testing.T, sourceName, namespace, targetName string) {
+	t.Helper()
+	obj := kubectlGetJSON(t, llmBatchGatewayKind, sourceName, namespace)
+
+	metadata, ok := obj["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("source CR %s has no metadata", sourceName)
+	}
+	metadata["name"] = targetName
+	metadata["namespace"] = namespace
+	delete(metadata, "uid")
+	delete(metadata, "resourceVersion")
+	delete(metadata, "generation")
+	delete(metadata, "creationTimestamp")
+	delete(metadata, "managedFields")
+	delete(metadata, "annotations")
+
+	delete(obj, "status")
+	kubectlCreateObject(t, obj)
 }


### PR DESCRIPTION
## Description

This PR adds the missing operator E2E coverage called out in #69 for RHOAI integration readiness.

Closes #69

It adds coverage for:
- operand pod readiness for `apiserver`, `processor`, and `gc`
- service reachability by checking both apiserver service endpoints and the user-facing API service port, plus the observability `/ready` endpoint
- `Ready=False` / `APIServerAvailable=False` transition and recovery when a critical operand is taken out of service
- full CR deletion cleanup by creating a temporary `LLMBatchGateway`, verifying owned operands are created with owner references, and verifying they are removed after CR deletion

It also cleans up the temporary CR clone helper to avoid copying source annotations into the generated test CR.

In addition, this PR fixes the local dev workflow so `make kustomize` and `make dev-deploy` work together without requiring a manual `PATH="$PWD/bin:$PATH"` override. `dev-deploy` now installs/uses the repo-local `bin/kustomize` consistently.

## How Has This Been Tested?

Manual / local validation:
- created a clean dev environment in Kind
- verified `make kustomize` works with the updated wiring
- verified `make dev-deploy` can use the repo-local `kustomize` binary
- patched the operator to use pullable operand images in this environment (`ghcr.io/llm-d/batch-gateway-*:latest`) because the current default `odh-stable` images were not pullable for the local cluster platform
- recreated `batch-gateway-dev` from a clean baseline before rerunning E2E to avoid stale CR spec patches from earlier runs

Tests run:
- `cd test/e2e && go test -run '^$'`
- targeted check for service reachability after updating the test to verify the user-facing service port
- full operator E2E suite:
  - `kubectl delete llmbatchgateway batch-gateway-dev -n default --ignore-not-found=true`
  - `kubectl apply -f config/samples/dev.yaml -n default`
  - `kubectl rollout status deployment/batch-gateway-dev-apiserver -n default --timeout=300s`
  - `kubectl rollout status deployment/batch-gateway-dev-processor -n default --timeout=300s`
  - `kubectl rollout status deployment/batch-gateway-dev-gc -n default --timeout=300s`
  - `cd test/e2e && TEST_CR_NAME=batch-gateway-dev go test -v -count=1 -timeout 10m ./...`

Result:
- full operator E2E suite passed locally from a clean CR baseline

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment scripts to use the locally installed `kustomize` tool consistently.
  * Made development deployments more reliable by ensuring bundled binaries are found automatically when needed.
  * Expanded end-to-end coverage for pod readiness, service access, status transitions, and cleanup behavior after deleting resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->