### PR TITLE
fix: resolve RBAC conflict, chart packaging, and CRD validation for RHOAI

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -17,13 +17,15 @@ COPY internal/ internal/
 # Obtain the batch-gateway Helm chart into /tmp/batch-gateway-chart.
 COPY Makefile ./
 
-RUN mkdir -p -m 777 /tmp/batch-gateway-chart
+RUN mkdir -p -m 777 /tmp/batch-gateway-chart /tmp/prefetched-charts
 # For all the crazy permisison denies
-COPY --chown=1001:0 Dockerfile prefetched-charts* /tmp/batch-gateway-chart/
+COPY --chown=1001:0 Dockerfile prefetched-charts* /tmp/prefetched-charts/
 
 RUN if [ "${BUILD_TYPE}" != "CI" ]; then \
         make fetch-batch-gateway && \
         cp -r batch-gateway/charts/batch-gateway/* /tmp/batch-gateway-chart/; \
+    else \
+        cp -r /tmp/prefetched-charts/batch-gateway/* /tmp/batch-gateway-chart/ 2>/dev/null || true; \
     fi
 
 RUN mkdir -p bin && \
@@ -35,7 +37,9 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d382
 WORKDIR /
 COPY --from=builder /opt/app-root/src/bin/manager /manager
 COPY --from=builder /tmp/batch-gateway-chart /charts/batch-gateway/
-RUN rm -f /charts/batch-gateway/Dockerfile
+RUN rm -f /charts/batch-gateway/Dockerfile && \
+    test -f /charts/batch-gateway/Chart.yaml || \
+    { echo "ERROR: /charts/batch-gateway/Chart.yaml not found. Chart directory contents:"; ls -la /charts/batch-gateway/; exit 1; }
 
 USER 1001:1001
 ENTRYPOINT ["/manager"]

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -479,8 +479,8 @@ type OTELSpec struct {
 // --- TLS ---
 
 // TLSSpec configures TLS termination for the API server.
-// +kubebuilder:validation:XValidation:rule="!self.enabled || size(self.secretName) > 0 || has(self.certManager)",message="tls.secretName or tls.certManager must be set when tls.enabled is true"
-// +kubebuilder:validation:XValidation:rule="!(size(self.secretName) > 0 && has(self.certManager))",message="tls.secretName and tls.certManager are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!self.enabled || (has(self.secretName) && size(self.secretName) > 0) || has(self.certManager)",message="tls.secretName or tls.certManager must be set when tls.enabled is true"
+// +kubebuilder:validation:XValidation:rule="!(has(self.secretName) && size(self.secretName) > 0 && has(self.certManager))",message="tls.secretName and tls.certManager are mutually exclusive"
 type TLSSpec struct {
 	// Enabled controls whether TLS termination is configured for the API server.
 	Enabled bool `json:"enabled,omitempty"`

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -831,9 +831,10 @@ spec:
                 x-kubernetes-validations:
                 - message: tls.secretName or tls.certManager must be set when tls.enabled
                     is true
-                  rule: '!self.enabled || size(self.secretName) > 0 || has(self.certManager)'
+                  rule: '!self.enabled || (has(self.secretName) && size(self.secretName)
+                    > 0) || has(self.certManager)'
                 - message: tls.secretName and tls.certManager are mutually exclusive
-                  rule: '!(size(self.secretName) > 0 && has(self.certManager))'
+                  rule: '!(has(self.secretName) && size(self.secretName) > 0 && has(self.certManager))'
             required:
             - apiServer
             - gc


### PR DESCRIPTION
## Description

fixes for RHOAI deployment:

1. **Dockerfile.konflux chart path**: Prefetched charts may nest under `batch-gateway/`, causing "Chart.yaml file is missing" at startup. Use `find` to locate `Chart.yaml` regardless of nesting, and add a build-time assertion.

2. **CRD CEL validation**: `size(self.secretName)` fails when field is absent. Guard with `has(self.secretName)`.

## How Has This Been Tested?

- Built image with `BUILD_TYPE=CI` and `prefetched-charts`: Chart.yaml check passed
- Deployed on RHOAI EA2 cluster with `aigateway.batchGateway.managementState: Managed`
- Verified LLMBatchGateway CR creation succeeds without `secretName: ""`

## Merge criteria

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [x] The developer has manually tested the changes and verified that the changes work.