### PR TITLE
fix: add missing nameprefix for rbac resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ lint:
 
 .PHONY: manifests
 manifests:
-	$(CONTROLLER_GEN) rbac:roleName=llm-d-batch-gateway-operator crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=operator crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate:

--- a/config/rbac/aggregate_roles.yaml
+++ b/config/rbac/aggregate_roles.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: llmbatchgateway-admin
+  name: admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -20,7 +20,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: llmbatchgateway-view
+  name: view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 - aggregate_roles.yaml
+namePrefix: llm-d-batch-gateway-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: llm-d-batch-gateway-operator
+  name: operator
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: llm-d-batch-gateway-operator
+  name: operator
   labels:
     app.kubernetes.io/name: llm-d-batch-gateway-operator
     app.kubernetes.io/managed-by: kustomize
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: llm-d-batch-gateway-operator
+  name: operator
 subjects:
 - kind: ServiceAccount
-  name: llm-d-batch-gateway-operator
+  name: operator

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: llm-d-batch-gateway-operator
+  name: operator
   namespace: system
   labels:
     app.kubernetes.io/name: llm-d-batch-gateway-operator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
refer to the fix in https://github.com/opendatahub-io/llm-d-batch-gateway-operator/pull/74 for RBAC
to consolidate the changes by unifying prefix to "llm-d-batch-gateway-"

this generates
```
Role: llm-d-batch-gateway-leader-election-role
RoleBinding: llm-d-batch-gateway-leader-election-rolebinding
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

attach generated resource
[result.txt](https://github.com/user-attachments/files/29369989/result.txt)



## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed exported RBAC ClusterRoles and related bindings to use simplified `admin`/`view` naming.
  * Updated operator-related RBAC resource names (roles, bindings, and the service account) from the old long prefix to `operator`.
  * Applied a new `namePrefix` to generated RBAC manifests, and updated generated RBAC artifacts used for CRD/webhook support to match the new naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->