### PR TITLE
fix: render inferenceObjective into inference gateway config

### DIFF
--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -492,7 +492,20 @@ func mergeProcessorConfig(m map[string]interface{}, cfg *batchv1alpha1.Processor
 			m["concurrency"] = concurrency
 		}
 	}
-	setIfNotEmpty(m, "inferenceObjective", cfg.InferenceObjective)
+	if cfg.InferenceObjective != "" {
+		if gw, ok := m["globalInferenceGateway"].(map[string]interface{}); ok {
+			setIfNotEmpty(gw, "inferenceObjective", cfg.InferenceObjective)
+		}
+		if mgs, ok := m["modelGateways"].(map[string]interface{}); ok {
+			for _, v := range mgs {
+				if mg, ok := v.(map[string]interface{}); ok {
+					if _, exists := mg["inferenceObjective"]; !exists {
+						mg["inferenceObjective"] = cfg.InferenceObjective
+					}
+				}
+			}
+		}
+	}
 	if cfg.DefaultOutputExpirationSeconds != 0 {
 		m["defaultOutputExpirationSeconds"] = cfg.DefaultOutputExpirationSeconds
 	}

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -743,8 +743,12 @@ func TestSpecToHelmValues_ProcessorConfig(t *testing.T) {
 	if got := concurrency["recovery"]; got != int64(4) {
 		t.Errorf("concurrency.recovery = %v, want 4", got)
 	}
-	if got := config["inferenceObjective"]; got != "throughput" {
-		t.Errorf("inferenceObjective = %v, want throughput", got)
+	gwConfig, ok := config["globalInferenceGateway"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("globalInferenceGateway not found or wrong type: %T", config["globalInferenceGateway"])
+	}
+	if got := gwConfig["inferenceObjective"]; got != "throughput" {
+		t.Errorf("globalInferenceGateway.inferenceObjective = %v, want throughput", got)
 	}
 	if got := config["defaultOutputExpirationSeconds"]; got != int64(7200) {
 		t.Errorf("defaultOutputExpirationSeconds = %v, want 7200", got)


### PR DESCRIPTION
## Description

`ProcessorConfigSpec.InferenceObjective` was set at the top level of processor Helm values, but the chart template expects it under `globalInferenceGateway`. Batch requests were dispatched at default priority (0) instead of the configured sheddable priority (-1).

Move `inferenceObjective` into the `globalInferenceGateway` map and propagate to `modelGateways` entries that don't set their own.

Fixes: https://github.com/opendatahub-io/llm-d-batch-gateway-operator/issues/76

## How Has This Been Tested?

- Unit test `TestSpecToHelmValues_ProcessorConfig` updated and passing
- Verified on RHOAI EA2 cluster: `inference_objective: batch-sheddable` appears in processor configmap under `global_inference_gateway`
- Flow control metrics confirm batch requests enqueued at priority -1

## Merge criteria

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [x] The developer has manually tested the changes and verified that the changes work.