### PR TITLE
feat: add new async image passed from caller(ai-gateway-operator)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,39 +29,41 @@ import (
 // It defaults to "dev" when built without the flag (e.g. go run).
 var version = "dev"
 
-// the way for batch-gateway-operator to know which exactly are the 3 component images(disgest) are via env variable set in the deployment
+// the way for batch-gateway-operator to know which exactly are the 4 component images(disgest) are via env variable set in the deployment
 // since it cannot read params.env which is updated by opendatahub-operator
 const (
 	envImageAPIServer = "LLM_D_BATCH_GATEWAY_APISERVER_IMAGE"
 	envImageProcessor = "LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE"
 	envImageGC        = "LLM_D_BATCH_GATEWAY_GC_IMAGE"
+	envImageAsync     = "LLM_D_ASYNC_IMAGE"
 )
 
 // componentImagesFromEnv reads the pinned component images from the environment
 // and fails if any are missing, since the operator cannot render workloads
 // without them.
 func componentImagesFromEnv() (controller.ComponentImages, error) {
-	images := controller.ComponentImages{
-		APIServer: os.Getenv(envImageAPIServer),
-		Processor: os.Getenv(envImageProcessor),
-		GC:        os.Getenv(envImageGC),
+	required := []string{
+		envImageAPIServer,
+		envImageProcessor,
+		envImageGC,
+		envImageAsync,
 	}
-
 	var missing []string
-	if images.APIServer == "" {
-		missing = append(missing, envImageAPIServer)
-	}
-	if images.Processor == "" {
-		missing = append(missing, envImageProcessor)
-	}
-	if images.GC == "" {
-		missing = append(missing, envImageGC)
+	for _, e := range required {
+		if os.Getenv(e) == "" {
+			missing = append(missing, e)
+		}
 	}
 	if len(missing) > 0 {
 		return controller.ComponentImages{}, fmt.Errorf("required image environment variables are not set: %s", strings.Join(missing, ", "))
 	}
 
-	return images, nil
+	return controller.ComponentImages{
+		APIServer: os.Getenv(envImageAPIServer),
+		Processor: os.Getenv(envImageProcessor),
+		GC:        os.Getenv(envImageGC),
+		Async:     os.Getenv(envImageAsync),
+	}, nil
 }
 
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;create;update;patch

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -63,3 +63,13 @@ replacements:
           name: llm-d-batch-gateway-operator
         fieldPaths:
           - spec.template.spec.containers.[name=manager].env.[name=LLM_D_BATCH_GATEWAY_GC_IMAGE].value
+  - source:
+      kind: ConfigMap
+      name: batch-gateway-operator-params
+      fieldPath: data.LLM_D_ASYNC_IMAGE
+    targets:
+      - select:
+          kind: Deployment
+          name: llm-d-batch-gateway-operator
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=LLM_D_ASYNC_IMAGE].value

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -2,3 +2,4 @@ LLM_D_BATCH_GATEWAY_OPERATOR_IMAGE=quay.io/opendatahub/odh-batch-gateway-operato
 LLM_D_BATCH_GATEWAY_APISERVER_IMAGE=quay.io/opendatahub/odh-llm-d-batch-gateway-apiserver:odh-stable
 LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE=quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
 LLM_D_BATCH_GATEWAY_GC_IMAGE=quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable
+LLM_D_ASYNC_IMAGE=quay.io/opendatahub/odh-llm-d-async:odh-stable

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,8 @@ spec:
           value: quay.io/opendatahub/odh-llm-d-batch-gateway-processor:odh-stable
         - name: LLM_D_BATCH_GATEWAY_GC_IMAGE
           value: quay.io/opendatahub/odh-llm-d-batch-gateway-gc:odh-stable
+        - name: LLM_D_ASYNC_IMAGE
+          value: quay.io/opendatahub/odh-llm-d-async:odh-stable
         - name: GOMEMLIMIT
           value: 200MiB
         ports:

--- a/hack/dev-deploy.sh
+++ b/hack/dev-deploy.sh
@@ -26,6 +26,7 @@ param_image() { grep -E "^$1=" "${PARAMS_ENV}" 2>/dev/null | head -n1 | cut -d= 
 APISERVER_IMG="${APISERVER_IMG:-$(param_image LLM_D_BATCH_GATEWAY_APISERVER_IMAGE)}"
 PROCESSOR_IMG="${PROCESSOR_IMG:-$(param_image LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE)}"
 GC_IMG="${GC_IMG:-$(param_image LLM_D_BATCH_GATEWAY_GC_IMAGE)}"
+ASYNC_IMG="${ASYNC_IMG:-$(param_image LLM_D_ASYNC_IMAGE)}"
 VLLM_SIM_IMG="${VLLM_SIM_IMG:-ghcr.io/llm-d/llm-d-inference-sim:latest}"
 
 # Port configuration (matches batch-gateway defaults)
@@ -248,7 +249,8 @@ deploy_operator() {
     kubectl set env deployment/llm-d-batch-gateway-operator -n "${OPERATOR_NAMESPACE}" \
         LLM_D_BATCH_GATEWAY_APISERVER_IMAGE="${APISERVER_IMG}" \
         LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE="${PROCESSOR_IMG}" \
-        LLM_D_BATCH_GATEWAY_GC_IMAGE="${GC_IMG}"
+        LLM_D_BATCH_GATEWAY_GC_IMAGE="${GC_IMG}" \
+        LLM_D_ASYNC_IMAGE="${ASYNC_IMG}"
 
     kubectl rollout status deployment/llm-d-batch-gateway-operator \
         -n "${OPERATOR_NAMESPACE}" --timeout=120s

--- a/internal/controller/helm.go
+++ b/internal/controller/helm.go
@@ -32,6 +32,7 @@ type ComponentImages struct {
 	APIServer string
 	Processor string
 	GC        string
+	Async     string
 }
 
 type HelmRenderer struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- follow the same patter how other 3 images
- set new env variable `LLM_D_ASYNC_IMAGE` on batch-gateway-operator deployment
- small refactor for loop over images if not set
ref AI gateway: https://github.com/opendatahub-io/ai-gateway-operator/pull/44
ref ODH https://github.com/opendatahub-io/opendatahub-operator/pull/3726

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and deploying an additional async component image.
  * The operator now expects one more image setting alongside the existing component images.

* **Bug Fixes**
  * Improved environment validation so missing image settings are detected more consistently.
  * Development deployment now passes the async image through correctly.

* **Chores**
  * Updated default deployment settings and configuration values to include the new image parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->