### PR TITLE
feat: enable CI tests on llm-d-async integration

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -15,6 +15,7 @@ on:
       - 'hack/**'
       - 'test/**'
       - 'Dockerfile'
+      - 'Dockerfile.konflux'
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
@@ -25,9 +26,19 @@ env:
 
 jobs:
   integration-tests:
-    name: Integration Tests
+    name: Integration Tests (${{ matrix.dev_profile }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dev_profile: sync
+          - dev_profile: async
+          - dev_profile: async-gate-redis
+          - dev_profile: async-gate-prometheus-query
+          - dev_profile: async-gate-prometheus-budget
+          - dev_profile: async-gate-scrape
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -41,16 +52,21 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
+      - name: Install yq
+        run: go install github.com/mikefarah/yq/v4@latest
+
       - name: Deploy dev environment
         run: make dev-deploy
         env:
           OPERATOR_IMG: ${{ env.OPERATOR_IMG }}
           KIND_CLUSTER_NAME: ${{ env.KIND_CLUSTER_NAME }}
+          DEV_PROFILE: ${{ matrix.dev_profile }}
 
       - name: Run batch-gateway e2e tests
         run: make test-e2e-batch-gateway
         env:
           TEST_APISERVER_URL: "http://localhost:8000"
+          TEST_RUN: "TestE2E/Batches/Lifecycle"
 
       - name: Run operator e2e tests
         run: make test-e2e-operator

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ KIND_CLUSTER_NAME ?= batch-gateway-dev
 ## The full batch-gateway repo is checked out in $(BATCH_GATEWAY_DIR); the operator uses its chart + e2e tests.
 ## This replaces the old git submodule solution.
 BATCH_GATEWAY_REPO ?= https://github.com/opendatahub-io/batch-gateway.git
-BATCH_GATEWAY_REF  ?= a672735cf19325d646a6ef33270df903cfdcd7cb
+BATCH_GATEWAY_REF  ?= fe4193060f239767a3c40154ef1acdfcbafa9b79
 BATCH_GATEWAY_DIR  ?= batch-gateway
 
 ## Only the async-processor chart is sparse-checked-out from llm-d-async.
 LLM_D_ASYNC_REPO ?= https://github.com/opendatahub-io/llm-d-async.git
-LLM_D_ASYNC_REF  ?= main
+LLM_D_ASYNC_REF  ?= 65c392c5ce4a0284c7b86b85b287d5e5fffda50b
 LLM_D_ASYNC_DIR  ?= llm-d-async
 
 ## Deps
@@ -139,7 +139,7 @@ TEST_RUN ?= TestE2E/Batches/Lifecycle
 
 .PHONY: test-e2e-batch-gateway
 test-e2e-batch-gateway: fetch-batch-gateway
-	cd $(BATCH_GATEWAY_DIR)/test/e2e && go test -v -count=1 -run "$(TEST_RUN)" ./...
+	bash hack/test-e2e-batch-gateway.sh
 
 .PHONY: test-e2e-operator
 test-e2e-operator: dev-deploy

--- a/api/v1alpha1/llmdasync_types.go
+++ b/api/v1alpha1/llmdasync_types.go
@@ -99,10 +99,18 @@ type AsyncRedisSpec struct {
 
 // AsyncQueueConfig configures a single Redis queue for the async-processor.
 type AsyncQueueConfig struct {
-	// Name identifies this queue configuration.
+	// Name is the Redis sorted-set key for this queue.
+	// Must follow the convention: llm-d-async:requests:<inferencePoolName>
+	// where <inferencePoolName> matches the corresponding modelGateways entry.
+	// The result queue (llm-d-async:results:<inferencePoolName>) is auto-configured by the batch processor.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name"`
+
+	// WorkerPoolID assigns this queue to a named worker pool.
+	// Must match a workerPools[].name entry. Defaults to "default" if omitted.
+	// +kubebuilder:validation:MaxLength=253
+	WorkerPoolID string `json:"workerPoolID,omitempty"`
 
 	// IGWBaseURL overrides the top-level asyncConfig.inferenceGateway URL for this queue.
 	// +kubebuilder:validation:MaxLength=2048

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -625,13 +625,23 @@ spec:
                                   pattern: ^https?://.+$
                                   type: string
                                 name:
-                                  description: Name identifies this queue configuration.
+                                  description: |-
+                                    Name is the Redis sorted-set key for this queue.
+                                    Must follow the convention: llm-d-async:requests:<inferencePoolName>
+                                    where <inferencePoolName> matches the corresponding modelGateways entry.
+                                    The result queue (llm-d-async:results:<inferencePoolName>) is auto-configured by the batch processor.
                                   maxLength: 253
                                   type: string
                                 requestPathURL:
                                   description: RequestPathURL overrides the request
                                     path for this queue.
                                   maxLength: 2048
+                                  type: string
+                                workerPoolID:
+                                  description: |-
+                                    WorkerPoolID assigns this queue to a named worker pool.
+                                    Must match a workerPools[].name entry. Defaults to "default" if omitted.
+                                  maxLength: 253
                                   type: string
                               required:
                               - name

--- a/config/samples/dev-async-gate-prometheus-budget.yaml
+++ b/config/samples/dev-async-gate-prometheus-budget.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch.llm-d.ai/v1alpha1
+kind: LLMBatchGateway
+metadata:
+  name: batch-gateway-dev
+spec:
+  secretRef:
+    name: batch-gateway-secrets
+  dbBackend: postgresql
+  fileStorage:
+    s3:
+      region: us-east-1
+      endpoint: http://minio.default.svc.cluster.local:9000
+      accessKeyId: minioadmin
+      usePathStyle: true
+      autoCreateBucket: true
+  apiServer:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+  gc:
+    interval: 30m
+    imagePullPolicy: IfNotPresent
+  processor:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+    dispatchMode: async
+    modelGateways:
+      sim-model:
+        inferencePoolName: sim-pool-prom-budget
+    asyncConfig:
+      replicas: 1
+      concurrency: 1
+      drainTimeout: 2m
+      prometheusURL: http://prometheus.default.svc.cluster.local:9090
+      prometheusCacheTTL: "0s"
+      redis:
+        requestPathURL: /v1/completions
+        pollIntervalMs: 500
+        batchSize: 10
+        queuesConfig:
+        - name: "llm-d-async:requests:sim-pool-prom-budget"     # format: llm-d-async:requests:<inferencePoolName> (from processor.modelGateways[].inferencePoolName)
+          requestPathURL: /v1/completions
+          igwBaseURL: http://vllm-sim.default.svc.cluster.local:8000
+          gateType: prometheus-budget
+          gateParams:
+            pool: sim-pool-prom-budget
+            max_concurrency: "5"
+            baseline: "0.05"
+            fallback: "1.0"
+          workerPoolID: sim-workers
+      workerPools:
+      - name: sim-workers
+        workers: 4
+        gateType: local-max-concurrency
+        gateParams:
+          limit: "2"

--- a/config/samples/dev-async-gate-prometheus-query.yaml
+++ b/config/samples/dev-async-gate-prometheus-query.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch.llm-d.ai/v1alpha1
+kind: LLMBatchGateway
+metadata:
+  name: batch-gateway-dev
+spec:
+  secretRef:
+    name: batch-gateway-secrets
+  dbBackend: postgresql
+  fileStorage:
+    s3:
+      region: us-east-1
+      endpoint: http://minio.default.svc.cluster.local:9000
+      accessKeyId: minioadmin
+      usePathStyle: true
+      autoCreateBucket: true
+  apiServer:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+  gc:
+    interval: 30m
+    imagePullPolicy: IfNotPresent
+  processor:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+    dispatchMode: async
+    modelGateways:
+      sim-model:
+        inferencePoolName: sim-pool-prom
+    asyncConfig:
+      replicas: 1
+      concurrency: 1
+      drainTimeout: 2m
+      prometheusURL: http://prometheus.default.svc.cluster.local:9090
+      prometheusCacheTTL: "0s"
+      redis:
+        requestPathURL: /v1/completions
+        pollIntervalMs: 500
+        batchSize: 10
+        queuesConfig:
+        - name: "llm-d-async:requests:sim-pool-prom"     # format: llm-d-async:requests:<inferencePoolName> (from processor.modelGateways[].inferencePoolName)
+          requestPathURL: /v1/completions
+          igwBaseURL: http://vllm-sim.default.svc.cluster.local:8000
+          gateType: prometheus-query
+          gateParams:
+            query: "1 - clamp_max(vllm:num_requests_waiting / 5, 1)"
+            fallback: "1.0"
+          workerPoolID: sim-workers
+      workerPools:
+      - name: sim-workers
+        workers: 4
+        gateType: local-max-concurrency
+        gateParams:
+          limit: "2"

--- a/config/samples/dev-async-gate-redis.yaml
+++ b/config/samples/dev-async-gate-redis.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch.llm-d.ai/v1alpha1
+kind: LLMBatchGateway
+metadata:
+  name: batch-gateway-dev
+spec:
+  secretRef:
+    name: batch-gateway-secrets
+  dbBackend: postgresql
+  fileStorage:
+    s3:
+      region: us-east-1
+      endpoint: http://minio.default.svc.cluster.local:9000
+      accessKeyId: minioadmin
+      usePathStyle: true
+      autoCreateBucket: true
+  apiServer:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+  gc:
+    interval: 30m
+    imagePullPolicy: IfNotPresent
+  processor:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+    dispatchMode: async
+    modelGateways:
+      sim-model:
+        inferencePoolName: sim-pool
+    asyncConfig:
+      replicas: 1
+      concurrency: 1
+      drainTimeout: 2m
+      redis:
+        requestPathURL: /v1/completions
+        pollIntervalMs: 500
+        batchSize: 10
+        queuesConfig:
+        - name: "llm-d-async:requests:sim-pool"     # format: llm-d-async:requests:<inferencePoolName> (from processor.modelGateways[].inferencePoolName)
+          requestPathURL: /v1/completions
+          igwBaseURL: http://vllm-sim.default.svc.cluster.local:8000
+          gateType: redis
+          gateParams:
+            address: "redis-master.default.svc.cluster.local:6379"
+          workerPoolID: sim-workers
+      workerPools:
+      - name: sim-workers
+        workers: 4
+        gateType: local-max-concurrency
+        gateParams:
+          limit: "2"

--- a/config/samples/dev-async-gate-scrape.yaml
+++ b/config/samples/dev-async-gate-scrape.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch.llm-d.ai/v1alpha1
+kind: LLMBatchGateway
+metadata:
+  name: batch-gateway-dev
+spec:
+  secretRef:
+    name: batch-gateway-secrets
+  dbBackend: postgresql
+  fileStorage:
+    s3:
+      region: us-east-1
+      endpoint: http://minio.default.svc.cluster.local:9000
+      accessKeyId: minioadmin
+      usePathStyle: true
+      autoCreateBucket: true
+  apiServer:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+  gc:
+    interval: 30m
+    imagePullPolicy: IfNotPresent
+  processor:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+    dispatchMode: async
+    modelGateways:
+      sim-model:
+        inferencePoolName: sim-pool-scrape
+    asyncConfig:
+      replicas: 1
+      concurrency: 1
+      drainTimeout: 2m
+      redis:
+        requestPathURL: /v1/completions
+        pollIntervalMs: 500
+        batchSize: 10
+        queuesConfig:
+        - name: "llm-d-async:requests:sim-pool-scrape"     # format: llm-d-async:requests:<inferencePoolName> (from processor.modelGateways[].inferencePoolName)
+          requestPathURL: /v1/completions
+          igwBaseURL: http://vllm-sim.default.svc.cluster.local:8000
+          gateType: endpoint-scrape
+          gateParams:
+            url: "http://vllm-sim.default.svc.cluster.local:8000/metrics"
+            metric: "vllm:num_requests_waiting"
+            max_count_per_pod: "5"
+            fallback: "1.0"
+          workerPoolID: sim-workers
+      workerPools:
+      - name: sim-workers
+        workers: 4
+        gateType: local-max-concurrency
+        gateParams:
+          limit: "2"

--- a/config/samples/dev-async.yaml
+++ b/config/samples/dev-async.yaml
@@ -16,36 +16,34 @@ spec:
   apiServer:
     replicas: 1
     imagePullPolicy: IfNotPresent
+  gc:
+    interval: 30m
+    imagePullPolicy: IfNotPresent
   processor:
     replicas: 1
     imagePullPolicy: IfNotPresent
     dispatchMode: async
-    globalInferenceGateway:
-      url: http://vllm-sim.default.svc:8000
-      requestTimeout: 5m
-      maxRetries: 3
-      initialBackoff: 1s
-      maxBackoff: 60s
-    # TODO: switch to modelGateways once batch-gateway chart supports dispatchMode=async (PR #458)
-    # modelGateways:
-    #   vllm-sim:
-    #     inferencePoolName: vllm-pool
+    modelGateways:
+      sim-model:
+        inferencePoolName: sim-pool
     asyncConfig:
       replicas: 1
       concurrency: 8
       drainTimeout: 2m
-      inferenceGateway:
-        url: http://epp.default.svc:8081
       redis:
         requestPathURL: /v1/completions
         pollIntervalMs: 1000
         batchSize: 10
-      transformConfig:
-        requestTransforms:
-        - name: gcs-whisper
-          type: gcs_uri_multipart
-          parameters:
-            providers: '["whisper","faster-whisper"]'
-  gc:
-    interval: 30m
-    imagePullPolicy: IfNotPresent
+        queuesConfig:
+        - name: "llm-d-async:requests:sim-pool"     # format: llm-d-async:requests:<inferencePoolName> (from processor.modelGateways[].inferencePoolName)
+          requestPathURL: /v1/completions
+          igwBaseURL: http://vllm-sim.default.svc:8000
+          workerPoolID: sim-workers
+      workerPools:
+      - name: sim-workers
+        workers: 4
+        gateType: local-max-concurrency
+        gateParams:
+          limit: "2"
+
+

--- a/config/samples/dev-sync.yaml
+++ b/config/samples/dev-sync.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch.llm-d.ai/v1alpha1
+kind: LLMBatchGateway
+metadata:
+  name: batch-gateway-dev
+spec:
+  secretRef:
+    name: batch-gateway-secrets
+  dbBackend: postgresql
+  fileStorage:
+    s3:
+      region: us-east-1
+      endpoint: http://minio.default.svc.cluster.local:9000
+      accessKeyId: minioadmin
+      usePathStyle: true
+      autoCreateBucket: true
+  apiServer:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+  gc:
+    interval: 30m
+    imagePullPolicy: IfNotPresent
+  processor:
+    replicas: 1
+    imagePullPolicy: IfNotPresent
+    dispatchMode: sync
+    globalInferenceGateway:
+      url: http://vllm-sim.default.svc:8000
+      requestTimeout: 5m
+      maxRetries: 3
+      initialBackoff: 1s
+      maxBackoff: 60s
+

--- a/hack/dev-clean.sh
+++ b/hack/dev-clean.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 NAMESPACE="${NAMESPACE:-default}"
+DEV_PROFILE="${DEV_PROFILE:-sync}"
 
 log()  { echo "  [INFO]  $*"; }
 step() { echo ""; echo "==> $*"; }
@@ -13,7 +14,7 @@ warn() { echo "  [WARN]  $*" >&2; }
 cd "${OPERATOR_DIR}"
 
 step "Deleting LLMBatchGateway CR..."
-kubectl delete -f config/samples/dev.yaml -n "${NAMESPACE}" --ignore-not-found --timeout=60s
+kubectl delete -f "config/samples/dev-${DEV_PROFILE}.yaml" -n "${NAMESPACE}" --ignore-not-found --timeout=60s
 
 step "Undeploying operator..."
 make undeploy 2>/dev/null || warn "undeploy failed (may already be removed)"
@@ -32,6 +33,10 @@ kubectl delete deployment,svc minio -n "${NAMESPACE}" --ignore-not-found
 
 step "Removing vLLM simulator..."
 kubectl delete deployment,svc vllm-sim -n "${NAMESPACE}" --ignore-not-found
+
+step "Removing Prometheus (if deployed by gate profile)..."
+kubectl delete deployment,svc,configmap -l app=prometheus -n "${NAMESPACE}" --ignore-not-found
+kubectl delete configmap prometheus-config -n "${NAMESPACE}" --ignore-not-found
 
 step "Removing NodePort services..."
 kubectl delete svc batch-gateway-apiserver-nodeport batch-gateway-processor-nodeport -n "${NAMESPACE}" --ignore-not-found

--- a/hack/dev-deploy.sh
+++ b/hack/dev-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,6 +20,11 @@ MINIO_REGION="${MINIO_REGION:-us-east-1}"
 GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-}"
 PROMETHEUS_OPERATOR_VERSION="${PROMETHEUS_OPERATOR_VERSION:-}"
 
+# Dev profile selects which config/samples/dev-<profile>.yaml CR to apply.
+# Available: sync (default), async, async-gate-redis, async-gate-prometheus-query,
+#            async-gate-prometheus-budget, async-gate-scrape.
+DEV_PROFILE="${DEV_PROFILE:-sync}"
+
 # read from params.env if you wanna test a different image, go update params.env
 PARAMS_ENV="${OPERATOR_DIR}/config/base/params.env"
 param_image() { grep -E "^$1=" "${PARAMS_ENV}" 2>/dev/null | head -n1 | cut -d= -f2- || true; }
@@ -37,18 +42,44 @@ LOCAL_PORT="${LOCAL_PORT:-8000}"
 LOCAL_OBS_PORT="${LOCAL_OBS_PORT:-8081}"
 LOCAL_PROCESSOR_PORT="${LOCAL_PROCESSOR_PORT:-9090}"
 
-# ── Logging ──────────────────────────────────────────────────────────────────
+# ── Utils ──────────────────────────────────────────────────────────────────
+TIMEOUT="${TIMEOUT:-180s}"
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
 
 log()  { echo "  [INFO]  $*"; }
 step() { echo ""; echo "==> $*"; }
 warn() { echo "  [WARN]  $*" >&2; }
 die()  { echo "  [FATAL] $*" >&2; exit 1; }
 
+wait_for() {
+    local desc="$1" check_cmd="$2"
+    local max=${TIMEOUT%s} elapsed=0
+    log "Waiting for $desc (timeout=${TIMEOUT})..."
+    while [ "$elapsed" -lt "$max" ]; do
+        if eval "$check_cmd" &>/dev/null; then
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+        elapsed=$((elapsed + POLL_INTERVAL))
+    done
+    return 1
+}
+
+wait_for_deployment() {
+    local name="$1" ns="$2"
+    if ! wait_for "deployment ${name} to exist" \
+        "kubectl get deployment/${name} -n ${ns}"; then
+        return 1
+    fi
+    kubectl wait "deployment/${name}" -n "$ns" \
+        --for="condition=Available" --timeout="${TIMEOUT}"
+}
+
 # ── Prerequisites ────────────────────────────────────────────────────────────
 
 CONTAINER_TOOL=""
 
-detect_CONTAINER_TOOL() {
+detect_container_tool() {
     if command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
         echo "docker"
     elif command -v podman &>/dev/null; then
@@ -64,13 +95,13 @@ check_prerequisites() {
         export PATH="${OPERATOR_DIR}/bin:${PATH}"
     fi
     local missing=()
-    for cmd in kubectl helm kind kustomize curl; do
+    for cmd in kubectl helm kind kustomize curl yq jq; do
         command -v "$cmd" &>/dev/null || missing+=("$cmd")
     done
     if [ ${#missing[@]} -gt 0 ]; then
         die "Missing required tools: ${missing[*]}"
     fi
-    CONTAINER_TOOL="$(detect_CONTAINER_TOOL)"
+    CONTAINER_TOOL="$(detect_container_tool)"
     if [ "${CONTAINER_TOOL}" = "podman" ]; then
         export KIND_EXPERIMENTAL_PROVIDER=podman
     fi
@@ -189,6 +220,8 @@ spec:
         - "8000"
         - --time-to-first-token=50ms
         - --inter-token-latency=100ms
+        - --fake-metrics
+        - '{"kv-cache-usage": 0, "waiting-requests": 0, "running-requests": 0}'
         ports:
         - containerPort: 8000
           name: http
@@ -213,12 +246,153 @@ EOF
     log "vLLM simulator installed."
 }
 
+# ── Gate Dependencies ───────────────────────────────────────────────────────
+
+# Gate types control when async-processor dispatches requests from the queue:
+#   redis             — reads a budget key from Redis; external systems set the value to open/close the gate
+#   prometheus-query   — evaluates a PromQL expression via Prometheus as the dispatch budget
+#   prometheus-budget  — cascades two Prometheus metric sources (primary: queue_size, fallback: vllm_running)
+#   endpoint-scrape   — directly scrapes a model server's /metrics endpoint to compute budget
+# All gates use a budget value in [0,1]: >0 dispatches, <=0 refuses.
+# See: https://github.com/llm-d-incubation/llm-d-async/blob/main/pkg/async/inference/flowcontrol/gate_factory.go
+prepare_gate_deps() {
+    case "${DEV_PROFILE}" in
+        sync|async)
+            ;;
+        async-gate-redis)
+            prepare_gate_redis
+            ;;
+        async-gate-prometheus-query)
+            prepare_gate_prometheus
+            ;;
+        async-gate-prometheus-budget)
+            prepare_gate_prometheus
+            ;;
+        async-gate-scrape)
+            prepare_gate_scrape
+            ;;
+        *)
+            die "Unknown DEV_PROFILE: ${DEV_PROFILE}"
+            ;;
+    esac
+}
+
+prepare_gate_redis() {
+    step "Setting Redis dispatch gate budget..."
+    wait_for "redis-master-0 to be ready" \
+        "kubectl get pod redis-master-0 -n ${NAMESPACE} -o jsonpath='{.status.phase}' | grep -q Running"
+    # The redis gate reads this key and applies a binary decision:
+    #   budget > 0  → dispatch (requests are processed)
+    #   budget <= 0 → refuse  (requests stay in queue)
+    # The value is exposed via the async_dispatch_budget metric.
+    # See: https://github.com/llm-d-incubation/llm-d-async/blob/main/pkg/redis/dispatch_gate.go
+    kubectl exec redis-master-0 -n "${NAMESPACE}" -- redis-cli SET dispatch-gate-budget 0.1
+    log "Redis gate budget set to 0.1."
+}
+
+prepare_gate_scrape() {
+    # The endpoint-scrape gate directly scrapes a model server's /metrics endpoint
+    # and computes dispatch budget from a specific metric.
+    # In dev-async-gate-scrape.yaml:
+    #   metric: vllm:num_requests_waiting, max_count_per_pod: 5
+    #   budget = 1 - (waiting / max_count_per_pod)
+    # vllm-sim --fake-metrics exposes waiting-requests=0, so budget = 1 - 0/5 = 1.0 (fully open).
+    # No extra setup needed — vllm-sim already has --fake-metrics enabled in install_vllm_sim.
+    # See: https://github.com/llm-d-incubation/llm-d-async/blob/main/pkg/async/inference/flowcontrol/gate_factory.go
+    step "Verifying vllm-sim /metrics endpoint..."
+    wait_for "vllm-sim metrics" \
+        "kubectl port-forward -n ${NAMESPACE} deployment/vllm-sim 18000:8000 &>/dev/null & sleep 2; curl -sf http://localhost:18000/metrics | grep -q vllm:num_requests_waiting; kill %1 2>/dev/null"
+    log "vllm-sim /metrics endpoint is ready."
+}
+
+prepare_gate_prometheus() {
+    # The prometheus-query gate evaluates a user-supplied PromQL expression as the dispatch budget.
+    # The expression must return a single value in [0, 1]:
+    #   budget > 0  → dispatch
+    #   budget <= 0 → refuse
+    # In dev-async-gate-prometheus-query.yaml the query is:
+    #   "1 - clamp_max(vllm:num_requests_waiting / 5, 1)"
+    # This computes budget based on vllm-sim's waiting requests metric.
+    # vllm-sim --fake-metrics exposes waiting-requests=0, so budget = 1 - 0/5 = 1.0 (fully open).
+    # See: https://github.com/llm-d-incubation/llm-d-async/blob/main/pkg/async/inference/flowcontrol/gate_factory.go
+    step "Installing Prometheus for gate testing..."
+
+    if kubectl get deployment prometheus -n "${NAMESPACE}" &>/dev/null; then
+        log "Prometheus already exists. Skipping install."
+    else
+        kubectl apply -n "${NAMESPACE}" -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+    scrape_configs:
+    - job_name: 'vllm-sim'
+      metrics_path: /metrics
+      static_configs:
+      - targets: ['vllm-sim.${NAMESPACE}.svc.cluster.local:8000']
+        labels:
+          component: vllm-sim
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v3.5.0
+        args:
+        - --config.file=/etc/prometheus/prometheus.yml
+        - --storage.tsdb.retention.time=1h
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - port: 9090
+    targetPort: 9090
+EOF
+        kubectl rollout status deployment prometheus -n "${NAMESPACE}" --timeout=120s
+    fi
+
+    step "Verifying Prometheus can scrape vllm-sim metrics..."
+    wait_for "vllm:num_requests_waiting in Prometheus" \
+        "kubectl port-forward -n ${NAMESPACE} deployment/prometheus 19090:9090 &>/dev/null & sleep 2; curl -sf 'http://localhost:19090/api/v1/query?query=vllm:num_requests_waiting' | grep -q success; kill %1 2>/dev/null"
+    log "Prometheus is scraping vllm-sim metrics."
+}
+
 # ── Operator ─────────────────────────────────────────────────────────────────
 
 build_operator() {
     step "Building operator image '${OPERATOR_IMG}'..."
     cd "${OPERATOR_DIR}"
-    local build_args=(-t "${OPERATOR_IMG}" -f Dockerfile)
+    local build_args=(-t "${OPERATOR_IMG}" -f Dockerfile.konflux)
     if [ "${CONTAINER_TOOL}" = "podman" ]; then
         build_args+=(--ignorefile Dockerfile.dockerignore)
     fi
@@ -245,7 +419,7 @@ deploy_operator() {
     IMG="${OPERATOR_IMG}" make deploy
 
     # override the env vars on the deployment to pin the images dev wants (defaults read from params.env.
-    step "Setting 4 component images on the operator deployment as env variable..."
+    step "Setting component images on the operator deployment as env variable..."
     kubectl set env deployment/llm-d-batch-gateway-operator -n "${OPERATOR_NAMESPACE}" \
         LLM_D_BATCH_GATEWAY_APISERVER_IMAGE="${APISERVER_IMG}" \
         LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE="${PROCESSOR_IMG}" \
@@ -262,9 +436,13 @@ apply_cr() {
     step "Applying dev LLMBatchGateway CR..."
     cd "${OPERATOR_DIR}"
 
-    kubectl apply -f config/samples/dev.yaml -n "${NAMESPACE}"
+    local cr_file="config/samples/dev-${DEV_PROFILE}.yaml"
+    if [ ! -f "${cr_file}" ]; then
+        die "Dev profile CR not found: ${cr_file} (DEV_PROFILE=${DEV_PROFILE})"
+    fi
+    kubectl apply -f "${cr_file}" -n "${NAMESPACE}"
 
-    log "CR applied. Operator will reconcile and create batch-gateway components."
+    log "CR applied (${cr_file}). Operator will reconcile and create batch-gateway components."
 }
 
 # ── NodePort Services ────────────────────────────────────────────────────────
@@ -321,26 +499,106 @@ EOF
 wait_for_batch_gateway() {
     step "Waiting for batch-gateway components..."
 
-    local timeout=180
-    local elapsed=0
-    while [ $elapsed -lt $timeout ]; do
-        local ready
-        ready=$(kubectl get deployments -n "${NAMESPACE}" \
-            -l "app.kubernetes.io/instance=batch-gateway-dev" \
-            -o jsonpath='{range .items[*]}{.status.readyReplicas}{"\n"}{end}' 2>/dev/null | grep -c "^[1-9]" || true)
+    local cr_name="batch-gateway-dev"
+    local cr_file="config/samples/dev-${DEV_PROFILE}.yaml"
 
-        if [ "$ready" -ge 3 ]; then
-            log "All batch-gateway components are ready."
-            return
+    # 1. Determine expected dispatch mode from profile name
+    local expected_dispatch="sync"
+    if [[ "${DEV_PROFILE}" == async* ]]; then
+        expected_dispatch="async"
+    fi
+
+    # 2. Verify CR's dispatchMode matches
+    local cr_dispatch_mode
+    cr_dispatch_mode=$(kubectl get llmbatchgateway "${cr_name}" -n "${NAMESPACE}" \
+        -o jsonpath='{.spec.processor.dispatchMode}')
+    if [[ "$cr_dispatch_mode" != "$expected_dispatch" ]]; then
+        die "CR dispatchMode is '$cr_dispatch_mode', expected '$expected_dispatch' (profile=${DEV_PROFILE})"
+    fi
+    log "CR dispatch mode verified: $cr_dispatch_mode"
+
+    # 3. Wait for all deployments
+    local components=("${cr_name}-apiserver" "${cr_name}-processor" "${cr_name}-gc")
+    if [[ "$expected_dispatch" == "async" ]]; then
+        components+=("${cr_name}-async-processor")
+    fi
+
+    for dep in "${components[@]}"; do
+        if ! wait_for_deployment "${dep}" "${NAMESPACE}"; then
+            kubectl get pods -n "${NAMESPACE}" -l "app.kubernetes.io/instance=${cr_name}"
+            return 1
         fi
-
-        sleep 5
-        elapsed=$((elapsed + 5))
-        log "Waiting... ($elapsed/${timeout}s, $ready/3 deployments ready)"
     done
 
-    warn "Timed out waiting for batch-gateway components. Showing current state:"
-    kubectl get pods -n "${NAMESPACE}"
+    # 4. Wait for CR Ready
+    if ! wait_for "CR ${cr_name} Ready" \
+        "kubectl get llmbatchgateway ${cr_name} -n ${NAMESPACE} -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' | grep -q True"; then
+        die "CR ${cr_name} not Ready"
+    fi
+
+    # 5. Verify processor configmap dispatch_mode matches
+    local processor_cm_data
+    processor_cm_data=$(kubectl get configmap -n "${NAMESPACE}" \
+        -l "app.kubernetes.io/instance=${cr_name},app.kubernetes.io/component=processor" \
+        -o jsonpath='{.items[0].data.config\.yaml}')
+    local cm_dispatch
+    cm_dispatch=$(echo "$processor_cm_data" | yq '.dispatch_mode // "sync"')
+    if [[ "$cm_dispatch" != "$expected_dispatch" ]]; then
+        die "Processor configmap dispatch_mode is '$cm_dispatch', expected '$expected_dispatch'"
+    fi
+    log "Processor configmap dispatch mode verified: $cm_dispatch"
+
+    # 6. Verify async-processor configuration from deployment spec
+    if [[ "$expected_dispatch" == "async" ]]; then
+        local deploy_json
+        deploy_json=$(kubectl get deployment "${cr_name}-async-processor" -n "${NAMESPACE}" -o json)
+        local queues_json
+        queues_json=$(echo "$deploy_json" | jq -r '.spec.template.spec.containers[0].args[]' | grep '^\[')
+
+        # Verify gate type if a gate profile is deployed
+        if [[ "${DEV_PROFILE}" == async-gate-* ]]; then
+            local expected_gate="${DEV_PROFILE##*gate-}"
+            case "$expected_gate" in
+                scrape) expected_gate="endpoint-scrape" ;;
+            esac
+
+            local actual_gate
+            actual_gate=$(echo "$queues_json" | jq -r '.[0].gate_type')
+
+            if [[ "$actual_gate" == "$expected_gate" ]]; then
+                log "Queue gate type verified: $actual_gate"
+            else
+                die "Expected queue gate type '$expected_gate', got '$actual_gate'"
+            fi
+        fi
+
+        # Verify worker pool from queuesConfig args
+        local pool_id
+        pool_id=$(echo "$queues_json" | jq -r '.[0].worker_pool_id')
+        if [[ "$pool_id" == "sim-workers" ]]; then
+            log "Worker pool verified: $pool_id"
+        else
+            die "Expected worker_pool_id 'sim-workers', got '$pool_id'"
+        fi
+
+        # Verify pool gate from ConfigMap matches CR
+        local cr_file="config/samples/dev-${DEV_PROFILE}.yaml"
+        local expected_pool_gate
+        expected_pool_gate=$(yq '.spec.processor.asyncConfig.workerPools[0].gateType' "$cr_file")
+        if [[ -n "$expected_pool_gate" && "$expected_pool_gate" != "null" ]]; then
+            local actual_pool_gate
+            actual_pool_gate=$(kubectl get configmap "${cr_name}-async-processor-config" -n "${NAMESPACE}" \
+                -o jsonpath='{.data.worker-pools\.json}' \
+                | jq -r '.[0].gate_type')
+            if [[ "$actual_pool_gate" == "$expected_pool_gate" ]]; then
+                log "Pool gate verified: $actual_pool_gate"
+            else
+                die "Expected pool gate '$expected_pool_gate', got '$actual_pool_gate'"
+            fi
+        fi
+    fi
+
+    log "All batch-gateway components are ready."
 }
 
 print_status() {
@@ -386,6 +644,7 @@ main() {
     install_prometheus_operator_crds
     install_prereqs
     install_vllm_sim
+    prepare_gate_deps
     load_operator
     deploy_operator
     apply_cr

--- a/hack/test-e2e-batch-gateway.sh
+++ b/hack/test-e2e-batch-gateway.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Runs batch-gateway e2e tests and verifies async dispatch via llm-d-async metrics.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BATCH_GATEWAY_DIR="${BATCH_GATEWAY_DIR:-batch-gateway}"
+TEST_RUN="${TEST_RUN:-}"
+NAMESPACE="${NAMESPACE:-default}"
+CR_NAME="${CR_NAME:-batch-gateway-dev}"
+
+log()  { echo "  [INFO]  $*"; }
+step() { echo ""; echo "==> $*"; }
+die()  { echo "  [FATAL] $*" >&2; exit 1; }
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+METRICS_PF_PID=""
+
+get_async_metrics() {
+    # Start port-forward if not already running
+    if [ -z "$METRICS_PF_PID" ] || ! kill -0 "$METRICS_PF_PID" 2>/dev/null; then
+        kubectl port-forward -n "${NAMESPACE}" \
+            "deployment/${CR_NAME}-async-processor" 19090:9090 &>/dev/null &
+        METRICS_PF_PID=$!
+        # Wait for port-forward to be ready
+        local attempt
+        for attempt in $(seq 1 30); do
+            if curl -sf http://localhost:19090/metrics &>/dev/null; then
+                break
+            fi
+            sleep 1
+        done
+    fi
+    curl -sf http://localhost:19090/metrics
+}
+
+cleanup_metrics_pf() {
+    if [ -n "$METRICS_PF_PID" ]; then
+        kill "$METRICS_PF_PID" 2>/dev/null
+        wait "$METRICS_PF_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_metrics_pf EXIT
+
+get_async_metric() {
+    local metric_name="$1"
+    # grep may return 1 if metric not yet emitted (no requests processed yet); default to 0
+    get_async_metrics | { grep "^${metric_name}" || true; } | awk '{sum+=$2} END {printf "%d", sum}'
+}
+
+# ── Detect dispatch mode from processor configmap ────────────────────────────
+
+dispatch_mode=$(kubectl get configmap -n "${NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${CR_NAME},app.kubernetes.io/component=processor" \
+    -o jsonpath='{.items[0].data.config\.yaml}' | yq '.dispatch_mode // "sync"')
+log "Detected dispatch mode: $dispatch_mode"
+
+# ── Record async metrics before tests ────────────────────────────────────────
+
+before_success=0
+if [[ "$dispatch_mode" == "async" ]]; then
+    step "Recording async metrics before tests..."
+    before_success=$(get_async_metric "llm_d_async_async_successful_requests_total")
+    log "async_successful_requests_total before: $before_success"
+fi
+
+# ── Run batch-gateway e2e tests ──────────────────────────────────────────────
+
+step "Running batch-gateway e2e tests..."
+cd "${OPERATOR_DIR}/${BATCH_GATEWAY_DIR}/test/e2e"
+go test -v -count=1 -run "${TEST_RUN}" ./...
+
+# ── Verify async dispatch via metrics ────────────────────────────────────────
+
+if [[ "$dispatch_mode" == "async" ]]; then
+    step "Verifying requests went through llm-d-async..."
+
+    after_success=$(get_async_metric "llm_d_async_async_successful_requests_total")
+    diff=$((after_success - before_success))
+
+    if [ "$diff" -gt 0 ]; then
+        log "Confirmed: $diff requests completed via llm-d-async ($before_success → $after_success)"
+    else
+        die "No requests went through llm-d-async (metric unchanged at $before_success)"
+    fi
+
+    # Verify worker pool is active
+    pool_metric=$(get_async_metric "llm_d_async_async_pool_worker_limit")
+    if [ "$pool_metric" -gt 0 ]; then
+        log "Worker pool active: pool_worker_limit=$pool_metric"
+    else
+        die "Worker pool not active (async_pool_worker_limit=0)"
+    fi
+
+    # Verify gate budget if a gate type is configured
+    gate_type=""
+    gate_type=$(kubectl get deployment "${CR_NAME}-async-processor" -n "${NAMESPACE}" -o json \
+        | jq -r '.spec.template.spec.containers[0].args[]' \
+        | grep '^\[' | jq -r '.[0].gate_type // empty')
+    if [ -n "$gate_type" ]; then
+        budget_line=$(get_async_metrics | grep "^llm_d_async_async_dispatch_budget" | head -1)
+        if [ -n "$budget_line" ]; then
+            log "Gate budget: $budget_line"
+        else
+            die "Gate not active: async_dispatch_budget metric not found"
+        fi
+    fi
+fi
+
+log "All batch-gateway e2e checks passed."

--- a/internal/controller/helm_async.go
+++ b/internal/controller/helm_async.go
@@ -79,8 +79,9 @@ func specToAsyncHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string,
 			var queues []any
 			for _, q := range ac.Redis.QueuesConfig {
 				qm := map[string]any{
-					"id": q.Name,
+					"queue_name": q.Name,
 				}
+				setIfNotEmpty(qm, "worker_pool_id", q.WorkerPoolID)
 				setIfNotEmpty(qm, "igw_base_url", q.IGWBaseURL)
 				setIfNotEmpty(qm, "request_path_url", q.RequestPathURL)
 				setIfNotEmpty(qm, "gate_type", q.GateType)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -107,13 +107,20 @@ func testCRDeletionCleanup(t *testing.T) {
 	cr := kubectlGetJSON(t, llmBatchGatewayKind, tempCRName, testNamespace)
 	ownerUID := getObjectUID(t, cr)
 
+	// async mode deploys 4 deployments/configmaps (includes async-processor), sync deploys 3
+	minDeployments := 3
+	minConfigmaps := 3
+	if isAsyncMode(t, testCRName, testNamespace) {
+		minDeployments = 4
+		minConfigmaps = 4
+	}
 	for _, tc := range []struct {
 		resource string
 		minCount int
 	}{
-		{resource: "deployment", minCount: 4},  // keep this updated with whats deployed via dev.yaml
+		{resource: "deployment", minCount: minDeployments},
 		{resource: "service", minCount: 1},
-		{resource: "configmap", minCount: 4},
+		{resource: "configmap", minCount: minConfigmaps},
 	} {
 		items := waitForResourceCountAtLeast(t, tc.resource, testNamespace, selector, tc.minCount, 120*time.Second)
 		for _, item := range items {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -111,6 +111,15 @@ func kubectlGetExists(t *testing.T, resource, name, namespace string) bool {
 	return false
 }
 
+func isAsyncMode(t *testing.T, crName, namespace string) bool {
+	t.Helper()
+	cr := kubectlGetJSON(t, llmBatchGatewayKind, crName, namespace)
+	spec, _ := cr["spec"].(map[string]any)
+	proc, _ := spec["processor"].(map[string]any)
+	mode, _ := proc["dispatchMode"].(string)
+	return mode == "async"
+}
+
 func kubectlGetJSON(t *testing.T, resource, name, namespace string) map[string]any {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
## Summary

- Update CI with 5 `LLMBatchGateway` CR with llm-d-async enabled, using different gate types (`redis`, `prometheus-query`, `prometheus-budget`, `endpoint-scrape`)
- Full E2E test: batch-api --> batch-processor --> llm-d-async --> vllm sim


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple new development async sample configurations (Redis-, Prometheus budget/query, and scrape-based gating), plus a sync sample.
  * Async queue configuration now supports assigning queues to a specific worker pool.
  * Dev deploy/cleanup now supports selecting a development profile.
* **Bug Fixes**
  * Improved deployment readiness/validation for sync vs async modes.
  * Updated e2e cleanup assertions and expectations for async deployments.
* **CI / Tests / Chores**
  * CI integration tests now run as a profile matrix with profile-specific deployments.
  * E2E batch-gateway tests now include conditional async metric, worker, and budget validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->