### PR TITLE
fix(ci): add llm-d-async chart fetch and skip builds on forks

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build-push:
     name: Build and Push
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,8 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Fetch batch-gateway chart
-        run: make fetch-batch-gateway
+      - name: Fetch charts
+        run: make sync-prefetched-charts
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3


### PR DESCRIPTION
## Description

- Add `fetch-llm-d-async` to chart fetch step (Dockerfile requires `llm-d-async/charts/async-processor`)
- Skip build on forks

## How Has This Been Tested?

Verified Dockerfile builds locally with both charts fetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI image workflow reliability by skipping image build-and-push jobs on forked repositories.
  * Updated the chart-fetching step to retrieve both required charts during CI, helping keep build inputs complete and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->