### PR TITLE
fix: move inferenceObjective from global to per inference gateway

### DIFF
--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -332,6 +332,10 @@ type InferenceGatewaySpec struct {
 	// +kubebuilder:validation:MaxLength=32
 	MaxBackoff string `json:"maxBackoff,omitempty"`
 
+	// InferenceObjective specifies the scheduling objective for this gateway (e.g. "throughput", "latency").
+	// +kubebuilder:validation:MaxLength=253
+	InferenceObjective string `json:"inferenceObjective,omitempty"`
+
 	// TLSInsecureSkipVerify disables TLS certificate verification. Not recommended for production.
 	TLSInsecureSkipVerify bool `json:"tlsInsecureSkipVerify,omitempty"`
 
@@ -400,10 +404,6 @@ type ProcessorConfigSpec struct {
 
 	// Concurrency groups all dispatch-rate and concurrency control knobs.
 	Concurrency *ConcurrencyConfig `json:"concurrency,omitempty"`
-
-	// InferenceObjective specifies the scheduling objective (e.g. "throughput", "latency").
-	// +kubebuilder:validation:MaxLength=253
-	InferenceObjective string `json:"inferenceObjective,omitempty"`
 
 	// DefaultOutputExpirationSeconds is the TTL for job output files.
 	DefaultOutputExpirationSeconds int64 `json:"defaultOutputExpirationSeconds,omitempty"`

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -478,6 +478,11 @@ spec:
                           InferenceGateway configures the connection to the inference gateway
                           EPP (EndpointPicker) service where inference requests are sent.
                         properties:
+                          inferenceObjective:
+                            description: InferenceObjective specifies the scheduling
+                              objective for this gateway (e.g. "throughput", "latency").
+                            maxLength: 253
+                            type: string
                           inferencePoolName:
                             description: |-
                               InferencePoolName identifies the async dispatch pool for this model.
@@ -878,11 +883,6 @@ spec:
                         description: EnablePprof enables the Go pprof profiling HTTP
                           endpoints.
                         type: boolean
-                      inferenceObjective:
-                        description: InferenceObjective specifies the scheduling objective
-                          (e.g. "throughput", "latency").
-                        maxLength: 253
-                        type: string
                       logging:
                         description: Logging configures log verbosity for the processor.
                         properties:
@@ -919,6 +919,11 @@ spec:
                       unless overridden by a ModelGateways entry.
                       Not supported when dispatchMode is "async"; use modelGateways with inferencePoolName instead.
                     properties:
+                      inferenceObjective:
+                        description: InferenceObjective specifies the scheduling objective
+                          for this gateway (e.g. "throughput", "latency").
+                        maxLength: 253
+                        type: string
                       inferencePoolName:
                         description: |-
                           InferencePoolName identifies the async dispatch pool for this model.
@@ -993,6 +998,11 @@ spec:
                       description: InferenceGatewaySpec configures a connection to
                         an inference gateway.
                       properties:
+                        inferenceObjective:
+                          description: InferenceObjective specifies the scheduling
+                            objective for this gateway (e.g. "throughput", "latency").
+                          maxLength: 253
+                          type: string
                         inferencePoolName:
                           description: |-
                             InferencePoolName identifies the async dispatch pool for this model.

--- a/internal/controller/helm_batch.go
+++ b/internal/controller/helm_batch.go
@@ -309,6 +309,7 @@ func inferenceGatewayToMap(gw *batchv1alpha1.InferenceGatewaySpec) map[string]in
 	setIfNotEmpty(m, "initialBackoff", gw.InitialBackoff)
 	setIfNotEmpty(m, "maxBackoff", gw.MaxBackoff)
 	setIfNotEmpty(m, "tlsCaCertFile", gw.TLSCACertFile)
+	setIfNotEmpty(m, "inferenceObjective", gw.InferenceObjective)
 	setIfNotEmpty(m, "tlsClientCertFile", gw.TLSClientCertFile)
 	setIfNotEmpty(m, "tlsClientKeyFile", gw.TLSClientKeyFile)
 	return m
@@ -397,20 +398,6 @@ func mergeProcessorConfig(m map[string]interface{}, cfg *batchv1alpha1.Processor
 		}
 		if len(concurrency) > 0 {
 			m["concurrency"] = concurrency
-		}
-	}
-	if cfg.InferenceObjective != "" {
-		if gw, ok := m["globalInferenceGateway"].(map[string]interface{}); ok {
-			setIfNotEmpty(gw, "inferenceObjective", cfg.InferenceObjective)
-		}
-		if mgs, ok := m["modelGateways"].(map[string]interface{}); ok {
-			for _, v := range mgs {
-				if mg, ok := v.(map[string]interface{}); ok {
-					if _, exists := mg["inferenceObjective"]; !exists {
-						mg["inferenceObjective"] = cfg.InferenceObjective
-					}
-				}
-			}
 		}
 	}
 	if cfg.DefaultOutputExpirationSeconds != 0 {

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -607,7 +607,7 @@ func TestSpecToHelmValues_ModelGateways(t *testing.T) {
 	gw := minimalGateway()
 	gw.Spec.Processor.GlobalInferenceGateway = nil
 	gw.Spec.Processor.ModelGateways = map[string]batchv1alpha1.InferenceGatewaySpec{
-		"model-a": {URL: "http://model-a:8000", RequestTimeout: "2m"},
+		"model-a": {URL: "http://model-a:8000", RequestTimeout: "2m", InferenceObjective: "latency"},
 	}
 
 	vals := specToBatchHelmValues(gw, testSecretName(gw), testImages())
@@ -621,6 +621,42 @@ func TestSpecToHelmValues_ModelGateways(t *testing.T) {
 	}
 	if got := ma["requestTimeout"]; got != "2m" {
 		t.Errorf("modelGateways.model-a.requestTimeout = %v", got)
+	}
+	if got := ma["inferenceObjective"]; got != "latency" {
+		t.Errorf("modelGateways.model-a.inferenceObjective = %v, want latency", got)
+	}
+}
+
+func TestSpecToHelmValues_PerGatewayInferenceObjective(t *testing.T) {
+	gw := minimalGateway()
+	gw.Spec.Processor.GlobalInferenceGateway = &batchv1alpha1.InferenceGatewaySpec{
+		URL:                "http://global:8000",
+		InferenceObjective: "throughput",
+	}
+	gw.Spec.Processor.ModelGateways = map[string]batchv1alpha1.InferenceGatewaySpec{
+		"model-a": {URL: "http://model-a:8000", InferenceObjective: "latency"},
+		"model-b": {URL: "http://model-b:8000"},
+	}
+
+	vals := specToBatchHelmValues(gw, testSecretName(gw), testImages())
+
+	processor := vals["processor"].(map[string]interface{})
+	config := processor["config"].(map[string]interface{})
+
+	gwConfig := config["globalInferenceGateway"].(map[string]interface{})
+	if got := gwConfig["inferenceObjective"]; got != "throughput" {
+		t.Errorf("globalInferenceGateway.inferenceObjective = %v, want throughput", got)
+	}
+
+	mg := config["modelGateways"].(map[string]interface{})
+	ma := mg["model-a"].(map[string]interface{})
+	if got := ma["inferenceObjective"]; got != "latency" {
+		t.Errorf("model-a.inferenceObjective = %v, want latency", got)
+	}
+
+	mb := mg["model-b"].(map[string]interface{})
+	if _, exists := mb["inferenceObjective"]; exists {
+		t.Errorf("model-b should not have inferenceObjective, got %v", mb["inferenceObjective"])
 	}
 }
 
@@ -710,6 +746,7 @@ func TestSpecToHelmValues_APIServerConfig(t *testing.T) {
 
 func TestSpecToHelmValues_ProcessorConfig(t *testing.T) {
 	gw := minimalGateway()
+	gw.Spec.Processor.GlobalInferenceGateway.InferenceObjective = "max-throughput"
 	gw.Spec.Processor.Config = &batchv1alpha1.ProcessorConfigSpec{
 		NumWorkers: 8,
 		Concurrency: &batchv1alpha1.ConcurrencyConfig{
@@ -717,7 +754,6 @@ func TestSpecToHelmValues_ProcessorConfig(t *testing.T) {
 			PerEndpoint: 16,
 			Recovery:    4,
 		},
-		InferenceObjective:             "throughput",
 		DefaultOutputExpirationSeconds: 7200,
 		ProgressTTLSeconds:             3600,
 		EnablePprof:                    true,
@@ -748,8 +784,8 @@ func TestSpecToHelmValues_ProcessorConfig(t *testing.T) {
 	if !ok {
 		t.Fatalf("globalInferenceGateway not found or wrong type: %T", config["globalInferenceGateway"])
 	}
-	if got := gwConfig["inferenceObjective"]; got != "throughput" {
-		t.Errorf("globalInferenceGateway.inferenceObjective = %v, want throughput", got)
+	if got := gwConfig["inferenceObjective"]; got != "max-throughput" {
+		t.Errorf("globalInferenceGateway.inferenceObjective = %v, want max-throughput", got)
 	}
 	if got := config["defaultOutputExpirationSeconds"]; got != int64(7200) {
 		t.Errorf("defaultOutputExpirationSeconds = %v, want 7200", got)


### PR DESCRIPTION
## Summary

Move `inferenceObjective` from global config to per inference gateway config, aligning the CRD with latest batch-gateway Helm chart structure.

- Add `InferenceObjective` field to `InferenceGatewaySpec`
- Map it in `inferenceGatewayToMap()`
- Remove dead fallback code from `mergeProcessorConfig()`
- Regenerate CRD manifests

Closes #86

## How Has This Been Tested?

`make test`: all unit tests pass, including new `TestSpecToHelmValues_PerGatewayInferenceObjective` covering per-gateway values and unset gateways.