### PR TITLE
feat: add s3 bucket field to CRD for single-bucket storage model

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -73,7 +73,6 @@ jobs:
         run: make test-e2e-batch-gateway
         env:
           TEST_APISERVER_URL: "http://localhost:8000"
-          TEST_RUN: "TestE2E/Batches/Lifecycle"
 
       - name: Run operator e2e tests
         run: make test-e2e-operator

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ KIND_CLUSTER_NAME ?= batch-gateway-dev
 ## The full batch-gateway repo is checked out in $(BATCH_GATEWAY_DIR); the operator uses its chart + e2e tests.
 ## This replaces the old git submodule solution.
 BATCH_GATEWAY_REPO ?= https://github.com/opendatahub-io/batch-gateway.git
-BATCH_GATEWAY_REF  ?= fe4193060f239767a3c40154ef1acdfcbafa9b79
+BATCH_GATEWAY_REF  ?= a9c01b34cd54c7d18701520f8a03008898acef70
 BATCH_GATEWAY_DIR  ?= batch-gateway
 
 ## Only the async-processor chart is sparse-checked-out from llm-d-async.

--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -126,6 +126,12 @@ type S3StorageSpec struct {
 	// +kubebuilder:validation:MaxLength=253
 	Region string `json:"region,omitempty"`
 
+	// Bucket is the S3 bucket name used for all file storage.
+	// Tenant isolation is achieved via S3 key prefixes, not separate buckets.
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MinLength=1
+	Bucket string `json:"bucket"`
+
 	// Endpoint overrides the S3 endpoint URL for non-AWS providers (e.g. MinIO).
 	// +kubebuilder:validation:MaxLength=2048
 	// +kubebuilder:validation:Pattern=`^https?://.+$`

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -299,6 +299,13 @@ spec:
                         description: AutoCreateBucket causes the operator to create
                           the bucket if it does not exist.
                         type: boolean
+                      bucket:
+                        description: |-
+                          Bucket is the S3 bucket name used for all file storage.
+                          Tenant isolation is achieved via S3 key prefixes, not separate buckets.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
                       endpoint:
                         description: Endpoint overrides the S3 endpoint URL for non-AWS
                           providers (e.g. MinIO).
@@ -318,6 +325,8 @@ spec:
                         description: UsePathStyle forces path-style addressing (required
                           by some S3-compatible stores).
                         type: boolean
+                    required:
+                    - bucket
                     type: object
                 type: object
                 x-kubernetes-validations:

--- a/config/samples/batch_v1alpha1_llmbatchgateway_async.yaml
+++ b/config/samples/batch_v1alpha1_llmbatchgateway_async.yaml
@@ -13,6 +13,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: https://s3.example.com
   apiServer:

--- a/config/samples/batch_v1alpha1_llmbatchgateway_sync.yaml
+++ b/config/samples/batch_v1alpha1_llmbatchgateway_sync.yaml
@@ -8,6 +8,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: https://s3.example.com
   apiServer:

--- a/config/samples/dev-async-gate-endpoint-scrape.yaml
+++ b/config/samples/dev-async-gate-endpoint-scrape.yaml
@@ -8,6 +8,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: http://minio.default.svc.cluster.local:9000
       accessKeyId: minioadmin

--- a/config/samples/dev-async-gate-prometheus-budget.yaml
+++ b/config/samples/dev-async-gate-prometheus-budget.yaml
@@ -8,6 +8,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: http://minio.default.svc.cluster.local:9000
       accessKeyId: minioadmin

--- a/config/samples/dev-async-gate-prometheus-query.yaml
+++ b/config/samples/dev-async-gate-prometheus-query.yaml
@@ -8,6 +8,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: http://minio.default.svc.cluster.local:9000
       accessKeyId: minioadmin

--- a/config/samples/dev-async-gate-redis.yaml
+++ b/config/samples/dev-async-gate-redis.yaml
@@ -8,6 +8,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: http://minio.default.svc.cluster.local:9000
       accessKeyId: minioadmin

--- a/config/samples/dev-async.yaml
+++ b/config/samples/dev-async.yaml
@@ -8,6 +8,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: http://minio.default.svc.cluster.local:9000
       accessKeyId: minioadmin

--- a/config/samples/dev-sync.yaml
+++ b/config/samples/dev-sync.yaml
@@ -8,6 +8,7 @@ spec:
   dbBackend: postgresql
   fileStorage:
     s3:
+      bucket: llm-d-batch-gateway
       region: us-east-1
       endpoint: http://minio.default.svc.cluster.local:9000
       accessKeyId: minioadmin

--- a/hack/test-e2e-batch-gateway.sh
+++ b/hack/test-e2e-batch-gateway.sh
@@ -16,15 +16,40 @@ die()  { echo "  [FATAL] $*" >&2; exit 1; }
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-METRICS_PF_PID=""
+PF_PIDS=()
+
+cleanup_port_forwards() {
+    for pid in "${PF_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null
+        wait "$pid" 2>/dev/null || true
+    done
+}
+trap cleanup_port_forwards EXIT
+
+start_port_forward() {
+    local resource="$1" local_port="$2" remote_port="$3"
+    kubectl port-forward -n "${NAMESPACE}" "$resource" "${local_port}:${remote_port}" &>/dev/null &
+    PF_PIDS+=($!)
+    local attempt
+    for attempt in $(seq 1 30); do
+        if curl -sf "http://localhost:${local_port}/" &>/dev/null 2>&1 || \
+           nc -z localhost "${local_port}" 2>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    die "Port-forward ${resource} ${local_port}:${remote_port} not ready after 30s"
+}
+
+ASYNC_METRICS_PF_PID=""
 
 get_async_metrics() {
     # Start port-forward if not already running
-    if [ -z "$METRICS_PF_PID" ] || ! kill -0 "$METRICS_PF_PID" 2>/dev/null; then
+    if [ -z "$ASYNC_METRICS_PF_PID" ] || ! kill -0 "$ASYNC_METRICS_PF_PID" 2>/dev/null; then
         kubectl port-forward -n "${NAMESPACE}" \
             "deployment/${CR_NAME}-async-processor" 19090:9090 &>/dev/null &
-        METRICS_PF_PID=$!
-        # Wait for port-forward to be ready
+        ASYNC_METRICS_PF_PID=$!
+        PF_PIDS+=("$ASYNC_METRICS_PF_PID")
         local attempt
         for attempt in $(seq 1 30); do
             if curl -sf http://localhost:19090/metrics &>/dev/null; then
@@ -36,17 +61,8 @@ get_async_metrics() {
     curl -sf http://localhost:19090/metrics
 }
 
-cleanup_metrics_pf() {
-    if [ -n "$METRICS_PF_PID" ]; then
-        kill "$METRICS_PF_PID" 2>/dev/null
-        wait "$METRICS_PF_PID" 2>/dev/null || true
-    fi
-}
-trap cleanup_metrics_pf EXIT
-
 get_async_metric() {
     local metric_name="$1"
-    # grep may return 1 if metric not yet emitted (no requests processed yet); default to 0
     get_async_metrics | { grep "^${metric_name}" || true; } | awk '{sum+=$2} END {printf "%d", sum}'
 }
 
@@ -57,26 +73,27 @@ dispatch_mode=$(kubectl get configmap -n "${NAMESPACE}" \
     -o jsonpath='{.items[0].data.config\.yaml}' | yq '.dispatch_mode // "sync"')
 log "Detected dispatch mode: $dispatch_mode"
 
-# ── Record async metrics before tests ────────────────────────────────────────
+# ── Run tests ────────────────────────────────────────────────────────────────
 
-before_success=0
+cd "${OPERATOR_DIR}/${BATCH_GATEWAY_DIR}/test/e2e"
+
 if [[ "$dispatch_mode" == "async" ]]; then
+    # The upstream TestE2E auto-skips in async mode. Run TestDispatcher instead
+    # to verify the async dispatch round-trip end-to-end.
+    TEST_RUN="${TEST_RUN:-TestDispatcher/BatchThroughDispatcher}"
+
+    step "Setting up port-forwards for async dispatcher tests..."
+    start_port_forward "svc/redis-master" 6399 6379
+    log "Port-forwards ready (redis:6399)"
+
     step "Recording async metrics before tests..."
     before_success=$(get_async_metric "llm_d_async_async_successful_requests_total")
     log "async_successful_requests_total before: $before_success"
-fi
 
-# ── Run batch-gateway e2e tests ──────────────────────────────────────────────
+    step "Running async dispatcher e2e tests (${TEST_RUN})..."
+    go test -v -count=1 -run "${TEST_RUN}" ./...
 
-step "Running batch-gateway e2e tests..."
-cd "${OPERATOR_DIR}/${BATCH_GATEWAY_DIR}/test/e2e"
-go test -v -count=1 -run "${TEST_RUN}" ./...
-
-# ── Verify async dispatch via metrics ────────────────────────────────────────
-
-if [[ "$dispatch_mode" == "async" ]]; then
     step "Verifying requests went through llm-d-async..."
-
     after_success=$(get_async_metric "llm_d_async_async_successful_requests_total")
     diff=$((after_success - before_success))
 
@@ -86,7 +103,6 @@ if [[ "$dispatch_mode" == "async" ]]; then
         die "No requests went through llm-d-async (metric unchanged at $before_success)"
     fi
 
-    # Verify worker pool is active
     pool_metric=$(get_async_metric "llm_d_async_async_pool_worker_limit")
     if [ "$pool_metric" -gt 0 ]; then
         log "Worker pool active: pool_worker_limit=$pool_metric"
@@ -107,6 +123,11 @@ if [[ "$dispatch_mode" == "async" ]]; then
             die "Gate not active: async_dispatch_budget metric not found"
         fi
     fi
+else
+    TEST_RUN="${TEST_RUN:-TestE2E/Batches/Lifecycle}"
+
+    step "Running batch-gateway e2e tests (${TEST_RUN})..."
+    go test -v -count=1 -run "${TEST_RUN}" ./...
 fi
 
 log "All batch-gateway e2e checks passed."

--- a/internal/controller/helm_batch.go
+++ b/internal/controller/helm_batch.go
@@ -29,6 +29,7 @@ func specToBatchHelmValues(gw *batchv1alpha1.LLMBatchGateway, secretName string,
 			s3 := gw.Spec.FileStorage.S3
 			s3Vals := map[string]any{}
 			setIfNotEmpty(s3Vals, "region", s3.Region)
+			setIfNotEmpty(s3Vals, "bucket", s3.Bucket)
 			setIfNotEmpty(s3Vals, "endpoint", s3.Endpoint)
 			setIfNotEmpty(s3Vals, "accessKeyId", s3.AccessKeyID)
 			if s3.Prefix != "" {

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -112,6 +112,7 @@ func TestSpecToHelmValues(t *testing.T) {
 			FileStorage: &batchv1alpha1.FileStorageSpec{
 				S3: &batchv1alpha1.S3StorageSpec{
 					Region:   "us-east-1",
+					Bucket:   "llm-d-batch-gateway",
 					Endpoint: "https://s3.example.com",
 				},
 			},
@@ -1040,6 +1041,7 @@ func minimalGateway() *batchv1alpha1.LLMBatchGateway {
 			FileStorage: &batchv1alpha1.FileStorageSpec{
 				S3: &batchv1alpha1.S3StorageSpec{
 					Region:   "us-east-1",
+					Bucket:   "llm-d-batch-gateway",
 					Endpoint: "https://s3.example.com",
 				},
 			},

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -36,6 +36,7 @@ func newTestGateway(name string) *batchv1alpha1.LLMBatchGateway {
 			FileStorage: &batchv1alpha1.FileStorageSpec{
 				S3: &batchv1alpha1.S3StorageSpec{
 					Region:   "us-east-1",
+					Bucket:   "llm-d-batch-gateway",
 					Endpoint: "https://s3.example.com",
 				},
 			},


### PR DESCRIPTION
## Summary

The upstream batch-gateway switched from per-tenant S3 buckets to a single configured bucket with tenant isolation via key prefixes ([llm-d/llm-d-batch-gateway#566](https://github.com/llm-d/llm-d-batch-gateway/pull/566)).

This PR updates the operator CRD and conversion layer to match:

- Add required `bucket` field to `S3StorageSpec` (minLength=1, maxLength=63)
- Pass `bucket` through to Helm values as `global.fileClient.s3.bucket`
- Update all sample CRs and test fixtures

## How Has This Been Tested?

- `make test` — all unit tests pass
- CRD validation enforces `bucket` is non-empty when S3 storage is configured
- Verified generated CRD includes the new field with correct constraints

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 storage configuration now requires a bucket name, and that value is passed through to deployed settings.
  * Updated sample configurations to include a default S3 bucket value for easier setup.

* **Bug Fixes**
  * Improved validation so incomplete S3 storage configs are rejected earlier.
  * Updated the pinned batch gateway reference to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->