### PR TITLE
fix: remove app.kubernetes.io/managed-by: kustomize label from resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     control-plane: llm-d-batch-gateway-controller-manager
     app.kubernetes.io/name: llm-d-batch-gateway-operator
-    app.kubernetes.io/managed-by: kustomize
 spec:
   replicas: 1
   selector:

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -4,7 +4,6 @@ metadata:
   name: leader-election-role
   labels:
     app.kubernetes.io/name: llm-d-batch-gateway-operator
-    app.kubernetes.io/managed-by: kustomize
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -4,7 +4,6 @@ metadata:
   name: leader-election-rolebinding
   labels:
     app.kubernetes.io/name: llm-d-batch-gateway-operator
-    app.kubernetes.io/managed-by: kustomize
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -4,7 +4,6 @@ metadata:
   name: operator
   labels:
     app.kubernetes.io/name: llm-d-batch-gateway-operator
-    app.kubernetes.io/managed-by: kustomize
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -5,4 +5,3 @@ metadata:
   namespace: system
   labels:
     app.kubernetes.io/name: llm-d-batch-gateway-operator
-    app.kubernetes.io/managed-by: kustomize


### PR DESCRIPTION
## Description
from https://github.com/opendatahub-io/ai-gateway-operator/pull/85:

The label was hardcoded on all resources (ServiceAccount, RoleBindings, Deployment, etc.). When the platform operator applies these via SSA with field manager "platform", it claims ownership of the managed-by field. This blocks Helm (rhai-on-xks chart) from co-managing the same resources (e.g. to inject imagePullSecrets), because Helm's SSA fails with:

  conflict with "platform": .metadata.labels.app.kubernetes.io/managed-by

Removing the label means "platform" no longer owns that field, allowing Helm to set app.kubernetes.io/managed-by: Helm without conflict.

## How Has This Been Tested?
Manually by syncing the changes to https://github.com/opendatahub-io/ai-gateway-operator

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Kustomize management label from Kubernetes deployment, RBAC, and service account resources.
  * Existing replicas, permissions, bindings, subjects, and container configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->