### PR TITLE
fix(deps): bump UBI9 base images to latest

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:0b0dd6f4ee311854a6b8e18b3bc52e7aa6b66f935a16c8f9bda173353ab16c64 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:5d26ff5606bd6590930e7cfc202b510e3fe2c7a7a1720860f444ab49c45128cb AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 ARG CGO_ENABLED=1
@@ -36,7 +36,7 @@ CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 GOEXPERIMENT=strictfipsruntime \
 go build -a -o bin/manager ./cmd/
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:907b68736aa798b2d38255b7aa070b2a70acb90803864a40f05d0ec47556ddd0
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1
 WORKDIR /
 COPY --from=builder /opt/app-root/src/bin/manager /manager
 COPY --from=builder /tmp/batch-gateway-chart /charts/batch-gateway/


### PR DESCRIPTION
Update ubi9/go-toolset:1.26 and ubi9/ubi-minimal:9.7 SHA pins to latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned base images used for building and running the application.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->