### PR TITLE
fix(tls): make metrics SecureServing configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,8 +16,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -96,6 +94,8 @@ func main() {
 	var batchGatewayChartPath string
 	var asyncChartPath string
 	var metricsAddr string
+	var metricsSecure bool
+	var metricsCertPath string
 	var probeAddr string
 	var enableLeaderElection bool
 	var syncPeriod time.Duration
@@ -104,6 +104,8 @@ func main() {
 	flag.StringVar(&batchGatewayChartPath, "batch-gateway-chart-path", "/charts/batch-gateway", "Path to the batch-gateway Helm chart directory")
 	flag.StringVar(&asyncChartPath, "async-chart-path", "/charts/async-processor", "Path to the async-processor Helm chart directory")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "Address the metrics endpoint binds to")
+	flag.BoolVar(&metricsSecure, "metrics-secure", true, "Serve metrics via HTTPS with authn/authz. Use --metrics-secure=false for HTTP on xKS.")
+	flag.StringVar(&metricsCertPath, "metrics-cert-path", "", "Directory containing the metrics server TLS cert and key. Empty uses in-memory certificates when --metrics-secure=true.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Address the health probe endpoint binds to")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager")
 	flag.DurationVar(&syncPeriod, "sync-period", syncPeriodDefault, "How often to re-sync all LLMBatchGateway resources to catch out-of-band drift")
@@ -129,14 +131,8 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme: scheme,
-		Metrics: metricsserver.Options{
-			BindAddress:    metricsAddr,
-			SecureServing:  true,
-			CertDir:        "/tmp/k8s-metrics-server/metrics-certs",
-			TLSOpts:        tlsResult.TLSOpts,
-			FilterProvider: filters.WithAuthenticationAndAuthorization,
-		},
+		Scheme:                 scheme,
+		Metrics:                metricsServerOptions(metricsAddr, metricsSecure, metricsCertPath, tlsResult.TLSOpts),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       utils.LeaderElectionID,

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// metricsServerOptions mirrors opendatahub-operator: HTTPS metrics and authn/authz
+// are gated on metrics-secure, and CertDir is set only when a cert path is provided
+// so xKS is not pointed at an empty optional service-ca volume.
+//
+// When certDir is set, TLSOpts also installs GetCertificate. controller-runtime
+// v0.23.3 otherwise checks tls.crt/tls.key once at listener create and falls back
+// to a self-signed cert that ServiceMonitor (service-ca) will never trust. Loading
+// on each handshake picks up the service-ca files when they appear on the optional
+// volume, instead of locking in that fallback.
+func metricsServerOptions(bindAddress string, secure bool, certDir string, tlsOpts []func(*tls.Config)) metricsserver.Options {
+	opts := metricsserver.Options{
+		BindAddress:   bindAddress,
+		SecureServing: secure,
+		TLSOpts:       append([]func(*tls.Config){}, tlsOpts...),
+	}
+	if secure {
+		opts.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+	if certDir != "" {
+		opts.CertDir = certDir
+		opts.TLSOpts = append(opts.TLSOpts, loadMetricsCertificate(certDir))
+	}
+	return opts
+}
+
+func loadMetricsCertificate(certDir string) func(*tls.Config) {
+	certPath := filepath.Join(certDir, "tls.crt")
+	keyPath := filepath.Join(certDir, "tls.key")
+	return func(c *tls.Config) {
+		c.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+			if err != nil {
+				return nil, fmt.Errorf("loading metrics serving certificate: %w", err)
+			}
+			return &cert, nil
+		}
+	}
+}

--- a/cmd/metrics_test.go
+++ b/cmd/metrics_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMetricsServerOptions(t *testing.T) {
+	tlsOpts := []func(*tls.Config){func(c *tls.Config) { c.MinVersion = tls.VersionTLS12 }}
+
+	t.Run("HTTP skips auth filter and cert dir", func(t *testing.T) {
+		opts := metricsServerOptions(":8080", false, "", tlsOpts)
+		if opts.BindAddress != ":8080" {
+			t.Errorf("BindAddress = %q, want :8080", opts.BindAddress)
+		}
+		if opts.SecureServing {
+			t.Error("SecureServing = true, want false")
+		}
+		if opts.FilterProvider != nil {
+			t.Error("FilterProvider should be nil when metrics-secure is false")
+		}
+		if opts.CertDir != "" {
+			t.Errorf("CertDir = %q, want empty", opts.CertDir)
+		}
+		if len(opts.TLSOpts) != 1 {
+			t.Errorf("TLSOpts len = %d, want 1", len(opts.TLSOpts))
+		}
+	})
+
+	t.Run("HTTPS enables auth filter without requiring a cert dir", func(t *testing.T) {
+		opts := metricsServerOptions(":8443", true, "", tlsOpts)
+		if !opts.SecureServing {
+			t.Error("SecureServing = false, want true")
+		}
+		if opts.FilterProvider == nil {
+			t.Error("FilterProvider should be set when metrics-secure is true")
+		}
+		if opts.CertDir != "" {
+			t.Errorf("CertDir = %q, want empty when cert path is unset", opts.CertDir)
+		}
+		if len(opts.TLSOpts) != 1 {
+			t.Errorf("TLSOpts len = %d, want 1", len(opts.TLSOpts))
+		}
+	})
+
+	t.Run("HTTPS with cert path sets CertDir and loads certs on handshake", func(t *testing.T) {
+		certDir := t.TempDir()
+		opts := metricsServerOptions(":8443", true, certDir, tlsOpts)
+		if !opts.SecureServing {
+			t.Error("SecureServing = false, want true")
+		}
+		if opts.FilterProvider == nil {
+			t.Error("FilterProvider should be set when metrics-secure is true")
+		}
+		if opts.CertDir != certDir {
+			t.Errorf("CertDir = %q, want %q", opts.CertDir, certDir)
+		}
+		if len(opts.TLSOpts) != 2 {
+			t.Errorf("TLSOpts len = %d, want 2", len(opts.TLSOpts))
+		}
+
+		cfg := &tls.Config{}
+		for _, opt := range opts.TLSOpts {
+			opt(cfg)
+		}
+		if cfg.GetCertificate == nil {
+			t.Fatal("GetCertificate should be set when cert path is provided")
+		}
+
+		if _, err := cfg.GetCertificate(&tls.ClientHelloInfo{}); err == nil {
+			t.Fatal("GetCertificate() succeeded with empty cert dir, want error")
+		}
+
+		writeTestServingCerts(t, certDir)
+		cert, err := cfg.GetCertificate(&tls.ClientHelloInfo{})
+		if err != nil {
+			t.Fatalf("GetCertificate() after writing certs: %v", err)
+		}
+		if cert == nil || len(cert.Certificate) == 0 {
+			t.Fatal("GetCertificate() returned empty certificate")
+		}
+	})
+}
+
+func writeTestServingCerts(t *testing.T, dir string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("writing tls.crt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}), 0o600); err != nil {
+		t.Fatalf("writing tls.key: %v", err)
+	}
+}

--- a/config/base/manager_metrics_patch.yaml
+++ b/config/base/manager_metrics_patch.yaml
@@ -1,3 +1,12 @@
+# Must live in config/base, not overlays/odh or overlays/rhoai.
+# ai-gateway-operator deploys this operator from SourcePath "base" only
+# (see INFERENG-10350 / #106). Overlay-only args/RBAC never reach the cluster.
 - op: add
-  path: /spec/template/spec/containers/0/args/0
+  path: /spec/template/spec/containers/0/args/-
   value: --metrics-bind-address=:8443
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-secure=true
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - manager.yaml
+- metrics_service.yaml

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -1,0 +1,27 @@
+# Applied with the Deployment (config/base and config/default both include this
+# directory). OpenShift service-ca watches this annotation and writes
+# llm-d-batch-gateway-operator-metrics-tls before or during pod start.
+# MetricsController still server-side applies the same Service after start
+# so drift is repaired; creating it only then is too late for
+# controller-runtime v0.23.3, which falls back to a self-signed cert if
+# tls.crt/tls.key are missing when the metrics listener is created.
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-d-batch-gateway-operator-metrics
+  namespace: system
+  labels:
+    control-plane: llm-d-batch-gateway-controller-manager
+    app.kubernetes.io/name: llm-d-batch-gateway-operator
+    app.kubernetes.io/managed-by: llmbatchgateway-controller
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: llm-d-batch-gateway-operator-metrics-tls
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: llm-d-batch-gateway-controller-manager
+    app.kubernetes.io/name: llm-d-batch-gateway-operator

--- a/internal/monitoring/controller.go
+++ b/internal/monitoring/controller.go
@@ -117,6 +117,9 @@ func (r *MetricsController) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
+// The same Service is declared in config/manager/metrics_service.yaml so
+// service-ca can issue the serving cert before the metrics listener starts.
+// This reconcile keeps the in-cluster object from drifting after that.
 func (r *MetricsController) reconcileMetricsService(ctx context.Context) (*corev1.Service, error) {
 	svc := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/monitoring/monitoring_test.go
+++ b/internal/monitoring/monitoring_test.go
@@ -2,12 +2,15 @@ package monitoring_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -131,4 +134,42 @@ func TestReconcileOperatorMonitoring(t *testing.T) {
 			t.Fatalf("second Reconcile() error: %v", err)
 		}
 	})
+}
+
+func TestMetricsServiceManifestMatchesReconciler(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "config", "manager", "metrics_service.yaml"))
+	if err != nil {
+		t.Fatalf("reading metrics Service manifest: %v", err)
+	}
+
+	var svc corev1.Service
+	if err := yaml.Unmarshal(data, &svc); err != nil {
+		t.Fatalf("decoding metrics Service manifest: %v", err)
+	}
+
+	wantName := utils.OperatorName + "-metrics"
+	if svc.Name != wantName {
+		t.Errorf("name = %q, want %q", svc.Name, wantName)
+	}
+
+	wantSecret := utils.OperatorName + "-metrics-tls"
+	if got := svc.Annotations["service.beta.openshift.io/serving-cert-secret-name"]; got != wantSecret {
+		t.Errorf("serving-cert annotation = %q, want %q", got, wantSecret)
+	}
+
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(svc.Spec.Ports))
+	}
+	if svc.Spec.Ports[0].Name != "https" {
+		t.Errorf("port name = %q, want https", svc.Spec.Ports[0].Name)
+	}
+	if svc.Spec.Ports[0].Port != 8443 {
+		t.Errorf("port = %d, want 8443", svc.Spec.Ports[0].Port)
+	}
+	if svc.Spec.Selector["app.kubernetes.io/name"] != utils.OperatorName {
+		t.Errorf("selector app.kubernetes.io/name = %q, want %q", svc.Spec.Selector["app.kubernetes.io/name"], utils.OperatorName)
+	}
+	if svc.Spec.Selector["control-plane"] != "llm-d-batch-gateway-controller-manager" {
+		t.Errorf("selector control-plane = %q, want llm-d-batch-gateway-controller-manager", svc.Spec.Selector["control-plane"])
+	}
 }


### PR DESCRIPTION
## Description

Follow-up to [#99](https://github.com/opendatahub-io/llm-d-batch-gateway-operator/pull/99) (SecureServing + TLS watcher) and [#106](https://github.com/opendatahub-io/llm-d-batch-gateway-operator/pull/106) (APIServer RBAC crashloop).

[#106](https://github.com/opendatahub-io/llm-d-batch-gateway-operator/pull/106) showed that ai-gateway-operator deploys this operator from `config/base` only (`SourcePath: "base"`). Overlay-only TLS RBAC never reached the cluster. This PR keeps the same constraint:

- `--metrics-secure` / `--metrics-cert-path` live in `config/base/manager_metrics_patch.yaml`, not `overlays/odh` or `overlays/rhoai`
- The `#106` `config.openshift.io/apiservers` rule stays in `config/rbac/role.yaml` and the kubebuilder marker in `cmd/main.go`

`kustomize build config/base` includes both the new flags and the APIServer RBAC.

Hardcoded `SecureServing` + `CertDir` plus an optional service-ca volume is the xKS gap from [ai-gateway-operator#96](https://github.com/opendatahub-io/ai-gateway-operator/pull/96#discussion_r3913911700). Empty `--metrics-cert-path` uses in-memory certificates instead of watching a missing volume. OpenShift/ai-gateway `base` still passes the service-ca cert path.

Follow-up: bump the batch-gateway SHA in ai-gateway-operator `hack/scripts/get-manifests.sh` after this merges (current pin `8b94572` is after #99 and before #106).

## How Has This Been Tested?
- `go test ./cmd/ -count=1`
- `kustomize build config/base` includes `--metrics-secure=true`, `--metrics-cert-path=...`, and `config.openshift.io/apiservers` get/list/watch

## Merge criteria
- [x] Commit messages are meaningful
- [x] Pull Request contains a description of the solution and related PRs
- [x] Testing instructions have been added in the PR body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Metrics serving is configurable through command-line options, including bind address, secure serving, and certificate directory.
  - Metrics use secure HTTPS serving by default with authentication and authorization filtering.
  - Insecure HTTP serving remains available for xKS environments.
  - Deployment configuration now supports metrics bind address and certificate settings.
  - Deployments expose the metrics endpoint through an HTTPS Service with automatic certificate provisioning.

- **Bug Fixes**
  - Improved metrics TLS behavior when no certificate directory is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->