### PR TITLE
Restore processor.config.inferenceObjective as a deprecated fallback

### DIFF
--- a/api/v1alpha1/llmbatchgateway_types.go
+++ b/api/v1alpha1/llmbatchgateway_types.go
@@ -438,6 +438,13 @@ type ProcessorConfigSpec struct {
 	// Concurrency groups all dispatch-rate and concurrency control knobs.
 	Concurrency *ConcurrencyConfig `json:"concurrency,omitempty"`
 
+	// InferenceObjective is applied to globalInferenceGateway and to every
+	// modelGateways entry that does not set its own inferenceObjective.
+	//
+	// Deprecated: set inferenceObjective on the gateway instead.
+	// +kubebuilder:validation:MaxLength=253
+	InferenceObjective string `json:"inferenceObjective,omitempty"`
+
 	// DefaultOutputExpirationSeconds is the TTL for job output files.
 	DefaultOutputExpirationSeconds int64 `json:"defaultOutputExpirationSeconds,omitempty"`
 

--- a/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
+++ b/config/crd/bases/batch.llm-d.ai_llmbatchgateways.yaml
@@ -1021,6 +1021,14 @@ spec:
                         maxLength: 32
                         pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                         type: string
+                      inferenceObjective:
+                        description: |-
+                          InferenceObjective is applied to globalInferenceGateway and to every
+                          modelGateways entry that does not set its own inferenceObjective.
+
+                          Deprecated: set inferenceObjective on the gateway instead.
+                        maxLength: 253
+                        type: string
                       logging:
                         description: Logging configures log verbosity for the processor.
                         properties:

--- a/internal/controller/helm_batch.go
+++ b/internal/controller/helm_batch.go
@@ -462,6 +462,19 @@ func mergeProcessorConfig(m map[string]interface{}, cfg *batchv1alpha1.Processor
 			m["concurrency"] = concurrency
 		}
 	}
+	legacyObjective := cfg.InferenceObjective //nolint:staticcheck // deprecated field is honored on purpose
+	if legacyObjective != "" {
+		if gw, ok := m["globalInferenceGateway"].(map[string]any); ok {
+			setDefaultObjective(gw, legacyObjective)
+		}
+		if mgs, ok := m["modelGateways"].(map[string]any); ok {
+			for _, v := range mgs {
+				if mg, ok := v.(map[string]any); ok {
+					setDefaultObjective(mg, legacyObjective)
+				}
+			}
+		}
+	}
 	if cfg.DefaultOutputExpirationSeconds != 0 {
 		m["defaultOutputExpirationSeconds"] = cfg.DefaultOutputExpirationSeconds
 	}
@@ -475,6 +488,12 @@ func mergeProcessorConfig(m map[string]interface{}, cfg *batchv1alpha1.Processor
 		m["enablePprof"] = true
 	}
 	setIfNotEmpty(m, "heartbeatInterval", cfg.HeartbeatInterval)
+}
+
+func setDefaultObjective(gw map[string]any, objective string) {
+	if _, exists := gw["inferenceObjective"]; !exists {
+		gw["inferenceObjective"] = objective
+	}
 }
 
 func resourceRequirementsToMap(r *corev1.ResourceRequirements) map[string]interface{} {

--- a/internal/controller/helm_test.go
+++ b/internal/controller/helm_test.go
@@ -671,6 +671,62 @@ func TestSpecToHelmValues_PerGatewayInferenceObjective(t *testing.T) {
 	}
 }
 
+func TestSpecToHelmValues_LegacyInferenceObjective(t *testing.T) {
+	tests := []struct {
+		name       string
+		global     *batchv1alpha1.InferenceGatewaySpec
+		models     map[string]batchv1alpha1.InferenceGatewaySpec
+		wantGlobal string
+		wantModels map[string]string
+	}{
+		{
+			name:       "fills global gateway",
+			global:     &batchv1alpha1.InferenceGatewaySpec{URL: "http://global:8000"},
+			wantGlobal: "batch-sheddable",
+		},
+		{
+			name:       "global gateway objective wins",
+			global:     &batchv1alpha1.InferenceGatewaySpec{URL: "http://global:8000", InferenceObjective: "own"},
+			wantGlobal: "own",
+		},
+		{
+			name: "fills model gateways that have none",
+			models: map[string]batchv1alpha1.InferenceGatewaySpec{
+				"model-a": {URL: "http://model-a:8000"},
+				"model-b": {URL: "http://model-b:8000", InferenceObjective: "own"},
+			},
+			wantModels: map[string]string{"model-a": "batch-sheddable", "model-b": "own"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := minimalGateway()
+			gw.Spec.Processor.GlobalInferenceGateway = tt.global
+			gw.Spec.Processor.ModelGateways = tt.models
+			gw.Spec.Processor.Config = &batchv1alpha1.ProcessorConfigSpec{InferenceObjective: "batch-sheddable"}
+
+			vals := specToBatchHelmValues(gw, testSecretName(gw), testImages(), tlspkg.ProfileValues{})
+			config := vals["processor"].(map[string]interface{})["config"].(map[string]interface{})
+
+			if _, exists := config["inferenceObjective"]; exists {
+				t.Errorf("processor.config.inferenceObjective should not be rendered, got %v", config["inferenceObjective"])
+			}
+			if tt.global != nil {
+				gwConfig := config["globalInferenceGateway"].(map[string]interface{})
+				if got := gwConfig["inferenceObjective"]; got != tt.wantGlobal {
+					t.Errorf("globalInferenceGateway.inferenceObjective = %v, want %s", got, tt.wantGlobal)
+				}
+			}
+			for model, want := range tt.wantModels {
+				mg := config["modelGateways"].(map[string]interface{})[model].(map[string]interface{})
+				if got := mg["inferenceObjective"]; got != want {
+					t.Errorf("modelGateways.%s.inferenceObjective = %v, want %s", model, got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestSpecToHelmValues_PrometheusRule(t *testing.T) {
 	gw := minimalGateway()
 	gw.Spec.PrometheusRule = &batchv1alpha1.PrometheusRuleSpec{

--- a/internal/controller/llmbatchgateway_controller.go
+++ b/internal/controller/llmbatchgateway_controller.go
@@ -54,6 +54,7 @@ const (
 
 	reasonReferenceNotPermitted = "ReferenceNotPermitted"
 	reasonSecretRefImmutable    = "SecretRefImmutable"
+	reasonDeprecatedField       = "DeprecatedField"
 )
 
 // managedGVKs must be a superset of all GVK types the Helm chart can produce.
@@ -180,6 +181,11 @@ func (r *LLMBatchGatewayReconciler) reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, fmt.Errorf("patching status after validation failure: %w", statusErr)
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if gw.Spec.Processor.Config != nil && gw.Spec.Processor.Config.InferenceObjective != "" { //nolint:staticcheck // deprecated field is honored on purpose
+		r.Recorder.Event(&gw, corev1.EventTypeWarning, reasonDeprecatedField,
+			"spec.processor.config.inferenceObjective is deprecated; set inferenceObjective on globalInferenceGateway or modelGateways.<model> instead")
 	}
 
 	// Resolve the credentials Secret, copying it into gw.Namespace when it

--- a/internal/controller/llmbatchgateway_controller_test.go
+++ b/internal/controller/llmbatchgateway_controller_test.go
@@ -409,7 +409,7 @@ func TestReconcile(t *testing.T) {
 			t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, updated.Generation)
 		}
 
-		assertEvent(t, fakeRecorder, corev1.EventTypeWarning, "ValidationFailed")
+		assertWarningEvent(t, fakeRecorder, "ValidationFailed")
 	})
 
 	t.Run("sets ValidationFailed when both gateways configured", func(t *testing.T) {
@@ -487,7 +487,7 @@ func TestReconcile(t *testing.T) {
 				if updated.Status.ObservedGeneration != updated.Generation {
 					t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, updated.Generation)
 				}
-				assertEvent(t, fakeRecorder, corev1.EventTypeWarning, reasonReferenceNotPermitted)
+				assertWarningEvent(t, fakeRecorder, reasonReferenceNotPermitted)
 				return
 			}
 		}
@@ -542,7 +542,7 @@ func TestReconcile(t *testing.T) {
 				if updated.Status.ObservedGeneration != updated.Generation {
 					t.Errorf("observedGeneration = %d, want %d", updated.Status.ObservedGeneration, updated.Generation)
 				}
-				assertEvent(t, fakeRecorder, corev1.EventTypeWarning, reasonSecretRefImmutable)
+				assertWarningEvent(t, fakeRecorder, reasonSecretRefImmutable)
 				return
 			}
 		}
@@ -783,6 +783,26 @@ func TestReconcile(t *testing.T) {
 		if checksumAfter == checksumBefore {
 			t.Error("processor deployment pod template not updated after config change")
 		}
+	})
+
+	t.Run("legacy processor.config.inferenceObjective lands on the gateway", func(t *testing.T) {
+		gw := newTestGateway("test-legacy-objective")
+		gw.Spec.Processor.Config = &batchv1alpha1.ProcessorConfigSpec{InferenceObjective: "batch-sheddable"}
+		if err := k8sClient.Create(ctx, gw); err != nil {
+			t.Fatalf("creating CR: %v", err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, gw) })
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace},
+		})
+		if err != nil {
+			t.Fatalf("Reconcile() error: %v", err)
+		}
+
+		cm := getOwnedConfigMap(ctx, t, gw, "processor")
+		assertConfigMapContains(t, cm, `inference_objective: "batch-sheddable"`)
+		assertWarningEvent(t, fakeRecorder, reasonDeprecatedField)
 	})
 
 	t.Run("gc config change updates ConfigMap and Deployment", func(t *testing.T) {
@@ -1178,19 +1198,19 @@ func assertResourceValue(t *testing.T, label string, list corev1.ResourceList, n
 	}
 }
 
-// assertEvent drains the fake recorder channel and asserts that at least one
-// event contains both the expected eventType and reason substring.
-func assertEvent(t *testing.T, recorder *record.FakeRecorder, eventType, reason string) {
+// assertWarningEvent drains the fake recorder channel and asserts that at least one
+// Warning event contains the expected reason substring.
+func assertWarningEvent(t *testing.T, recorder *record.FakeRecorder, reason string) {
 	t.Helper()
 	for {
 		select {
 		case got := <-recorder.Events:
-			if strings.Contains(got, eventType) && strings.Contains(got, reason) {
+			if strings.Contains(got, corev1.EventTypeWarning) && strings.Contains(got, reason) {
 				return
 			}
 			// Drain other events that don't match (e.g. from previous subtests).
 		default:
-			t.Errorf("expected event with type %q and reason %q but none found", eventType, reason)
+			t.Errorf("expected Warning event with reason %q but none found", reason)
 			return
 		}
 	}


### PR DESCRIPTION
bdc9f53 moved `inferenceObjective` onto the gateway specs and dropped it from `ProcessorConfigSpec`. The CRD prunes unknown fields, so a CR still using `spec.processor.config.inferenceObjective` loses the value with no error and the processor stops sending `x-gateway-inference-objective`.

This puts the field back, marked deprecated. It fills `globalInferenceGateway` and any `modelGateways` entry that has no objective of its own; a gateway-level value always wins. Reconcile emits a `DeprecatedField` warning event when the old path is in use.

Notes
- Verified on a live cluster: with the current CRD a strict apply is rejected and a lenient apply stores the CR without the field, ConfigMap has no `inference_objective`. With this CRD the same CR is accepted, the ConfigMap gets `inference_objective: "batch-sheddable"` under the global gateway, and the event fires.
- A CR that was already pruned needs a re-apply after the CRD upgrade; the stored object no longer has the value.
- No admission webhook, so the deprecation shows in events and `kubectl explain`, not at apply time.

Fixes #108
